### PR TITLE
Feat/download – download pipeline, reliability fixes, updated tests and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ tests/*
 
 # logs
 logs/*
+
+# docs -- not yet ready for public release
+docs/deployment.md
+docs/contributing.md

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ dfs/bin/*
 dfs/test-data/*
 dfs/tests/integration/test_files/*
 tests/*
+
+# logs
+logs/*

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@
 # Some build stuff
 bin/*
 dfs/bin/*
+
+# test files
+dfs/test-data/*
+dfs/tests/integration/test_files/*
+tests/*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Connect to server",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "remotePath": "/app",
+            "port": 2345,
+            "host": "127.0.0.1",
+            "cwd": "${workspaceFolder}/dfs",
+            "showLog": true
+        }
+    ]
+}

--- a/dfs/Makefile
+++ b/dfs/Makefile
@@ -21,9 +21,12 @@ build: proto
 	@go build -o bin/client ./cmd/client
 	@echo "Build complete"
 
+# Optional log file for docker compose output (can be overridden: `make integration LOG_FILE=my.log`)
+LOG_FILE ?= ../logs/integration_run.log
+
 integration:
-	@echo "Running integration tests"
-	@docker compose -f docker-compose.test.yml up --build
+	@echo "Running integration tests (logs -> $(LOG_FILE))"
+	@docker compose -f docker-compose.test.yml up --build 2>&1 | tee $(LOG_FILE)
 
 integration-down:
 	@echo "Downing containers..."

--- a/dfs/cmd/datanode/main.go
+++ b/dfs/cmd/datanode/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mochivi/distributed-file-system/internal/common"
 	"github.com/mochivi/distributed-file-system/internal/datanode"
 	"github.com/mochivi/distributed-file-system/internal/storage/chunk"
+	"github.com/mochivi/distributed-file-system/internal/storage/encoding"
 	"github.com/mochivi/distributed-file-system/pkg/logging"
 	"github.com/mochivi/distributed-file-system/pkg/proto"
 	"github.com/mochivi/distributed-file-system/pkg/utils"
@@ -213,11 +214,15 @@ func initServer(nodeConfig datanode.DataNodeConfig, logger *slog.Logger) (*datan
 	// ChunkStore implementation is chosen here
 	baseDir := utils.GetEnvString("DISK_STORAGE_BASE_DIR", "/app")
 	rootDir := filepath.Join(baseDir, "data")
-	chunkStore, err := chunk.NewChunkDiskStorage(chunk.DiskStorageConfig{
+
+	diskStorageConfig := chunk.DiskStorageConfig{
 		Enabled: true,
 		Kind:    "block",
 		RootDir: rootDir,
-	}, logger)
+	}
+	chunkSerializer := encoding.NewProtoSerializer()
+
+	chunkStore, err := chunk.NewChunkDiskStorage(diskStorageConfig, chunkSerializer, logger)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/dfs/deploy/docker/integration.Dockerfile
+++ b/dfs/deploy/docker/integration.Dockerfile
@@ -3,6 +3,9 @@ FROM golang:1.24-alpine
 # Install necessary tools for testing
 RUN apk add --no-cache wget curl
 
+# Install Delve debugger
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
 # Set working directory
 WORKDIR /app
 

--- a/dfs/deploy/scripts/client-test.sh
+++ b/dfs/deploy/scripts/client-test.sh
@@ -24,4 +24,19 @@ echo "All test files created:"
 ls -lh ${TEST_FILES_DIR}/*test*.txt
 
 echo "running tests..."
-go test -v -parallel 8 -timeout=300s ./tests/integration/...
+
+if [ "$DEBUG" = "true" ]; then
+    echo "Running in debug mode - waiting for debugger connection on port 2345"
+    # Run specific test with debugger
+    if [ -n "$TEST_NAME" ]; then
+        dlv test --headless --listen=:2345 --api-version=2 --accept-multiclient --log -- -test.run="$TEST_NAME" ./tests/integration/... 
+    else
+        # Run all tests with debugger
+        dlv test --headless --listen=:2345 --api-version=2 --accept-multiclient --log ./tests/integration/...
+    fi
+else
+    echo "Running in normal mode"
+    # Your original test logic here
+    # Replace this with the contents of your original client-test.sh
+    go test -v -parallel 8 -timeout=300s ./tests/integration/...
+fi

--- a/dfs/docker-compose.test.yml
+++ b/dfs/docker-compose.test.yml
@@ -22,7 +22,8 @@ services:
       - DATANODE_HOST=datanode1
       - DISK_STORAGE_BASE_DIR=/app
     depends_on:
-      - coordinator
+      coordinator:
+        condition: service_started
     networks:
       - dfs-network
 
@@ -38,7 +39,8 @@ services:
       - DATANODE_HOST=datanode2
       - DISK_STORAGE_BASE_DIR=/app
     depends_on:
-      - coordinator
+      coordinator:
+        condition: service_started
     networks:
       - dfs-network
 
@@ -54,7 +56,8 @@ services:
       - DATANODE_HOST=datanode3
       - DISK_STORAGE_BASE_DIR=/app
     depends_on:
-      - coordinator
+      coordinator:
+        condition: service_started
     networks:
       - dfs-network
 
@@ -70,7 +73,8 @@ services:
       - DATANODE_HOST=datanode4
       - DISK_STORAGE_BASE_DIR=/app
     depends_on:
-      - coordinator
+      coordinator:
+        condition: service_started
     networks:
       - dfs-network
 
@@ -86,7 +90,8 @@ services:
       - DATANODE_HOST=datanode5
       - DISK_STORAGE_BASE_DIR=/app
     depends_on:
-      - coordinator
+      coordinator:
+        condition: service_started
     networks:
       - dfs-network
 
@@ -102,7 +107,8 @@ services:
       - DATANODE_HOST=datanode6
       - DISK_STORAGE_BASE_DIR=/app
     depends_on:
-      - coordinator
+      coordinator:
+        condition: service_started
     networks:
       - dfs-network
 
@@ -127,8 +133,8 @@ services:
       - datanode6
     networks:
       - dfs-network
-    tmpfs: #Store test files in RAM to avoid disk I/O and SSD wear
-      - /app/test-files:size=2G
+    # tmpfs: #Store test files in RAM to avoid disk I/O and SSD wear
+    #   - /app/test-files:size=2G
     ports:
       - "2345:2345"
 

--- a/dfs/docker-compose.test.yml
+++ b/dfs/docker-compose.test.yml
@@ -116,6 +116,7 @@ services:
       - COORDINATOR_HOST=coordinator
       - COORDINATOR_PORT=8080
       - ENVIRONMENT=production # TODO: reduces logging verbosity, add log level as env var
+      - DEBUG=${DEBUG_INTEGRATION_TESTS:-false}
     depends_on:
       - coordinator
       - datanode1
@@ -126,6 +127,10 @@ services:
       - datanode6
     networks:
       - dfs-network
+    tmpfs: #Store test files in RAM to avoid disk I/O and SSD wear
+      - /app/test-files:size=2G
+    ports:
+      - "2345:2345"
 
 networks:
   dfs-network:

--- a/dfs/internal/client/client.go
+++ b/dfs/internal/client/client.go
@@ -51,7 +51,7 @@ func (c *Client) UploadFile(ctx context.Context, file *os.File, path string, chu
 		NumWorkers:      10,
 		ChunkRetryCount: 3,
 	})
-	chunkInfos, err := uploader.UploadFile(uploadCtx, file, uploadResponse.ChunkLocations, uploadResponse.SessionID, metadataSessionLogger)
+	chunkInfos, err := uploader.UploadFile(uploadCtx, file, uploadResponse.ChunkLocations, uploadResponse.SessionID, metadataSessionLogger, chunksize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload file: %w", err)
 	}

--- a/dfs/internal/client/client.go
+++ b/dfs/internal/client/client.go
@@ -3,41 +3,29 @@ package client
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
-	"sync"
 
 	"github.com/mochivi/distributed-file-system/internal/common"
 	"github.com/mochivi/distributed-file-system/internal/coordinator"
-	"github.com/mochivi/distributed-file-system/internal/datanode"
 	"github.com/mochivi/distributed-file-system/pkg/logging"
 )
 
-// Define the datatype that workers will receive
-type Work struct {
-	sessionID string
-	chunkMeta common.ChunkMeta
-	data      []byte
-	client    *datanode.DataNodeClient
-	logger    *slog.Logger
-}
-
-func (c *Client) UploadFile(ctx context.Context, file *os.File, path string, chunksize int) (map[string]*common.ChunkInfo, error) {
+func (c *Client) UploadFile(ctx context.Context, file *os.File, path string, chunksize int) error {
 	logger := logging.ExtendLogger(c.logger, slog.String("operation", "upload_file"), slog.String("path", path))
 
 	// Stat the file to get the file info
 	fileInfo, err := file.Stat()
 	if err != nil {
 		logger.Error("Failed to stat file", slog.String("error", err.Error()))
-		return nil, fmt.Errorf("failed to stat file: %w", err)
+		return fmt.Errorf("failed to stat file: %w", err)
 	}
 
 	checksum, err := common.CalculateFileChecksum(file)
 	if err != nil {
 		logger.Error("Failed to calculate checksum", slog.String("error", err.Error()))
-		return nil, fmt.Errorf("failed to calculate checksum")
+		return fmt.Errorf("failed to calculate checksum")
 	}
 
 	uploadRequest := coordinator.UploadRequest{
@@ -50,182 +38,70 @@ func (c *Client) UploadFile(ctx context.Context, file *os.File, path string, chu
 
 	uploadResponse, err := c.coordinatorClient.UploadFile(ctx, uploadRequest)
 	if err != nil {
-		return nil, fmt.Errorf("failed to submit upload request: %w", err)
+		return fmt.Errorf("failed to submit upload request: %w", err)
 	}
 	metadataSessionLogger := logging.ExtendLogger(logger, slog.String("metadata_session_id", uploadResponse.SessionID), slog.String("coordinator_id", c.coordinatorClient.Node.ID))
 	metadataSessionLogger.Info("Received UploadResponse")
 
-	// Control all the goroutines and requests we will make
 	uploadCtx, cancel := context.WithCancel(ctx)
-	defer cancel() // any early return will terminate the created goroutines
+	defer cancel()
 
-	// Worker pool
-	const numWorkers = 10
-	var wg sync.WaitGroup
-
-	// Make one channel to receive the work, one to write any errors into
-	workChan := make(chan Work, numWorkers) // At most numWorkers chunks will be processed at a time, to avoid too much memory usage
-	errChan := make(chan error, len(uploadResponse.ChunkLocations))
-	chunkInfos := make(map[string]*common.ChunkInfo, len(uploadResponse.ChunkLocations))
-	chunkInfosMutex := sync.Mutex{}
-
-	// Launch the worker pool
-	metadataSessionLogger.Info("Initializing worker pool", slog.Int("num_workers", numWorkers))
-	for i := range numWorkers {
-		wg.Add(1)
-		go func(workerID int) {
-			defer wg.Done()
-			if err := c.processChunkWorker(uploadCtx, workChan, &chunkInfos, &chunkInfosMutex); err != nil {
-				metadataSessionLogger.Error(fmt.Sprintf("Worker %d failed", workerID), slog.String("error", err.Error()))
-				errChan <- err
-			}
-		}(i)
+	// Uploader submits requests to all datanodes with each chunk
+	uploader := NewUploader(c.streamer, metadataSessionLogger, UploaderConfig{
+		NumWorkers:      10,
+		ChunkRetryCount: 3,
+	})
+	chunkInfos, err := uploader.UploadFile(uploadCtx, file, uploadResponse.ChunkLocations, uploadResponse.SessionID, metadataSessionLogger)
+	if err != nil {
+		return fmt.Errorf("failed to upload file: %w", err)
 	}
 
-	// Read file and queue work
-	metadataSessionLogger.Info("Reading file and queueing work", slog.Int("num_chunks", len(uploadResponse.ChunkLocations)))
-	for i, chunkUploadLocation := range uploadResponse.ChunkLocations {
-		chunkData := make([]byte, chunksize)
-		n, err := file.Read(chunkData)
-		if err != nil && err != io.EOF {
-			close(workChan)
-			logger.Error("Failed to read chunk", slog.Int("chunk_index", i), slog.String("error", err.Error()))
-			return nil, fmt.Errorf("failed to read chunk %d: %w", i, err)
-		}
-		chunkData = chunkData[:n]
-
-		checksum := common.CalculateChecksum(chunkData)
-		chunkMeta := common.ChunkMeta{
-			ChunkID:   chunkUploadLocation.ChunkID,
-			ChunkSize: len(chunkData),
-			Checksum:  checksum,
-		}
-
-		client, err := datanode.NewDataNodeClient(chunkUploadLocation.Node)
-		if err != nil {
-			metadataSessionLogger.Error("Failed to create connection to datanode client", slog.String("error", err.Error()))
-			return nil, fmt.Errorf("failed to create connection to datanode client: %w", err)
-		}
-
-		// Check if client accepts to store the chunk
-		storeChunkResponse, err := client.StoreChunk(ctx, chunkMeta)
-		if err != nil {
-			return nil, fmt.Errorf("failed to store chunk %s: %w", chunkMeta.ChunkID, err)
-		}
-
-		if !storeChunkResponse.Accept {
-			return nil, fmt.Errorf("failed to accept chunk %s: %s", chunkMeta.ChunkID, storeChunkResponse.Message)
-		}
-		metadataSessionLogger.Info("Chunk accepted", slog.String("chunk_id", chunkMeta.ChunkID))
-
-		streamingSessionLogger := logging.ExtendLogger(metadataSessionLogger, slog.String("streaming_session_id", storeChunkResponse.SessionID), slog.String("datanode_id", client.Node.ID))
-		workChan <- Work{
-			sessionID: storeChunkResponse.SessionID, // streaming sessionID, NOT metadata sessionID
-			chunkMeta: chunkMeta,
-			data:      chunkData,
-			client:    client,
-			logger:    streamingSessionLogger,
-		}
-	}
-
-	// Finish writing work into the workChan
-	close(workChan)
-
-	// Close error channel when all goroutines complete
-	// Looks a bit odd to wg.Wait inside a goroutine but the ErrChan blocks until its closed below
-	go func() {
-		wg.Wait()
-		close(errChan)
-	}()
-
-	// Currently, returning on exactly the first error received
-	for err := range errChan {
-		if err != nil {
-			metadataSessionLogger.Error("Error in worker", slog.String("error", err.Error()))
-			return nil, err
-		}
-	}
-
-	// Now, we need to confirm the upload to the coordinator, so that the metadata is updated
-	// This is done by sending a ConfirmUploadRequest to the coordinator
-	chunkInfosSlice := make([]common.ChunkInfo, 0, len(chunkInfos))
-	for _, chunkInfo := range chunkInfos {
-		chunkInfosSlice = append(chunkInfosSlice, *chunkInfo)
-	}
+	// Confirm upload to coordinator with chunk location information
 	confirmUploadRequest := coordinator.ConfirmUploadRequest{
 		SessionID:  uploadResponse.SessionID, // metadata sessionID, NOT streaming sessionID
-		ChunkInfos: chunkInfosSlice,
+		ChunkInfos: chunkInfos,
 	}
 	confirmUploadResponse, err := c.coordinatorClient.ConfirmUpload(ctx, confirmUploadRequest)
 	if err != nil {
 		metadataSessionLogger.Error("Failed to confirm upload", slog.String("error", err.Error()))
-		return nil, fmt.Errorf("failed to confirm upload: %w", err)
+		return fmt.Errorf("failed to confirm upload: %w", err)
 	}
 
 	if !confirmUploadResponse.Success {
 		metadataSessionLogger.Error("Failed to confirm upload", slog.String("message", confirmUploadResponse.Message))
-		return nil, fmt.Errorf("failed to confirm upload")
-	}
-
-	return chunkInfos, nil
-}
-
-// Processes work from workChan
-func (c *Client) processChunkWorker(ctx context.Context, workChan chan Work, chunkInfos *map[string]*common.ChunkInfo, chunkInfosMutex *sync.Mutex) error {
-	for work := range workChan {
-		// Retry loop
-		retryCount := 0
-		for retryCount < 3 {
-			if err := c.processChunk(ctx, work, work.logger); err != nil {
-				retryCount++
-				if retryCount >= 3 {
-					return fmt.Errorf("failed to store chunk %s after %d retries", work.chunkMeta.ChunkID, retryCount)
-				}
-			} else {
-				break // break out of the retry loop
-			}
-		}
-
-		// Update chunk infos - this information is sent to the coordinator to update the metadata about the chunk
-		chunkInfosMutex.Lock()
-		entry, ok := (*chunkInfos)[work.chunkMeta.ChunkID]
-		if !ok { // if chunk id has not been replicated yet, add the first replica
-			newEntry := common.ChunkInfo{
-				ID:       work.chunkMeta.ChunkID,
-				Checksum: work.chunkMeta.Checksum,
-				Size:     work.chunkMeta.ChunkSize,
-				Replicas: []*common.DataNodeInfo{work.client.Node},
-			}
-			(*chunkInfos)[work.chunkMeta.ChunkID] = &newEntry
-		} else { // Add replica to the chunk info
-			entry.Replicas = append(entry.Replicas, work.client.Node)
-		}
-		chunkInfosMutex.Unlock()
-
-		work.logger.Info("Chunk stored")
+		return fmt.Errorf("failed to confirm upload")
 	}
 
 	return nil
 }
 
-func (c *Client) processChunk(ctx context.Context, work Work, streamingLogger *slog.Logger) error {
-	streamingLogger.Info("Streaming chunk")
+func (c *Client) DownloadFile(ctx context.Context, path string) (string, error) {
+	logger := logging.ExtendLogger(c.logger, slog.String("operation", "download_file"), slog.String("path", path))
 
-	// Open stream to send chunk data to the datanode
-	stream, err := work.client.StreamChunk(ctx)
+	downloadResponse, err := c.coordinatorClient.DownloadFile(ctx, coordinator.DownloadRequest{Path: path})
 	if err != nil {
-		return fmt.Errorf("failed to create stream for chunk %s: %w", work.chunkMeta.ChunkID, err)
+		logger.Error("Failed to download file", slog.String("error", err.Error()))
+		return "", fmt.Errorf("failed to download file %s: %w", path, err)
 	}
 
-	if err := c.streamer.StreamChunk(ctx, stream, streamingLogger, common.StreamChunkParams{
-		SessionID: work.sessionID,
-		ChunkMeta: work.chunkMeta,
-		Data:      work.data,
-	}); err != nil {
-		return fmt.Errorf("failed to stream chunk %s: %w", work.chunkMeta.ChunkID, err)
+	if downloadResponse.SessionID == "" {
+		logger.Error("No session id returned for download file", slog.String("path", path))
+		return "", fmt.Errorf("no session id returned for download file %s", path)
 	}
 
-	streamingLogger.Info("Chunk streaming completed")
+	// Control all the goroutines and requests we will make
+	downloadCtx, cancel := context.WithCancel(ctx)
+	defer cancel() // any early return will terminate the created goroutines
 
-	return nil
+	downloader := NewDownloader(DownloaderConfig{
+		NumWorkers:      10,
+		ChunkRetryCount: 3,
+	}, c.streamer)
+
+	tempFile, err := downloader.DownloadFile(downloadCtx, downloadResponse.ChunkLocations, downloadResponse.SessionID, int(downloadResponse.FileInfo.Size), logger)
+	if err != nil {
+		return "", fmt.Errorf("failed to download file: %w", err)
+	}
+
+	return tempFile, nil
 }

--- a/dfs/internal/client/client.go
+++ b/dfs/internal/client/client.go
@@ -51,7 +51,7 @@ func (c *Client) UploadFile(ctx context.Context, file *os.File, path string, chu
 		NumWorkers:      10,
 		ChunkRetryCount: 3,
 	})
-	chunkInfos, err := uploader.UploadFile(uploadCtx, file, uploadResponse.ChunkLocations, uploadResponse.SessionID, metadataSessionLogger, chunksize)
+	chunkInfos, err := uploader.UploadFile(uploadCtx, file, uploadResponse.ChunkLocations, metadataSessionLogger, chunksize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload file: %w", err)
 	}

--- a/dfs/internal/client/client.go
+++ b/dfs/internal/client/client.go
@@ -45,13 +45,7 @@ func (c *Client) UploadFile(ctx context.Context, file *os.File, path string, chu
 
 	uploadCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-
-	// Uploader submits requests to all datanodes with each chunk
-	uploader := NewUploader(c.streamer, metadataSessionLogger, UploaderConfig{
-		NumWorkers:      10,
-		ChunkRetryCount: 3,
-	})
-	chunkInfos, err := uploader.UploadFile(uploadCtx, file, uploadResponse.ChunkLocations, metadataSessionLogger, chunksize)
+	chunkInfos, err := c.uploader.UploadFile(uploadCtx, file, uploadResponse.ChunkLocations, metadataSessionLogger, chunksize)
 	if err != nil {
 		return nil, fmt.Errorf("failed to upload file: %w", err)
 	}
@@ -92,13 +86,7 @@ func (c *Client) DownloadFile(ctx context.Context, path string) (string, error) 
 	// Control all the goroutines and requests we will make
 	downloadCtx, cancel := context.WithCancel(ctx)
 	defer cancel() // any early return will terminate the created goroutines
-
-	downloader := NewDownloader(DownloaderConfig{
-		NumWorkers:      10,
-		ChunkRetryCount: 3,
-	}, c.streamer)
-
-	tempFile, err := downloader.DownloadFile(downloadCtx, downloadResponse.ChunkLocations, downloadResponse.SessionID, int(downloadResponse.FileInfo.Size), logger)
+	tempFile, err := c.downloader.DownloadFile(downloadCtx, downloadResponse.ChunkLocations, downloadResponse.SessionID, int(downloadResponse.FileInfo.Size), logger)
 	if err != nil {
 		return "", fmt.Errorf("failed to download file: %w", err)
 	}

--- a/dfs/internal/client/downloader.go
+++ b/dfs/internal/client/downloader.go
@@ -49,7 +49,7 @@ type downloadSession struct {
 	logger   *slog.Logger // scoped to the upload session
 }
 
-func NewDownloader(config DownloaderConfig, streamer *common.Streamer) *Downloader {
+func NewDownloader(streamer *common.Streamer, config DownloaderConfig) *Downloader {
 	return &Downloader{
 		config:   config,
 		streamer: streamer,

--- a/dfs/internal/client/downloader.go
+++ b/dfs/internal/client/downloader.go
@@ -181,7 +181,7 @@ func (d *Downloader) queueWork(session *downloadSession, sessionID string) error
 			return err
 		}
 
-		client, err := datanode.NewDataNodeClient(location.Node)
+		client, err := datanode.NewDataNodeClient(location.Nodes[0])
 		if err != nil {
 			return fmt.Errorf("failed to create datanode client: %w", err)
 		}

--- a/dfs/internal/client/downloader.go
+++ b/dfs/internal/client/downloader.go
@@ -1,0 +1,228 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+
+	"github.com/mochivi/distributed-file-system/internal/common"
+	"github.com/mochivi/distributed-file-system/internal/coordinator"
+	"github.com/mochivi/distributed-file-system/internal/datanode"
+)
+
+type DownloaderConfig struct {
+	NumWorkers      int
+	ChunkRetryCount int
+	TempDir         string // directory to store temporary files
+}
+
+type DownloadWork struct {
+	chunkID    string
+	chunkIndex int
+	client     *datanode.DataNodeClient
+	sessionID  string
+	logger     *slog.Logger
+}
+
+type Downloader struct {
+	config   DownloaderConfig
+	streamer *common.Streamer
+}
+
+type downloadSession struct {
+	// Input params
+	chunkLocations []coordinator.ChunkLocation
+	chunksize      int
+
+	// Output params
+	tempFile     *os.File
+	fileMutex    sync.Mutex
+	tempFileSize int64
+
+	// Internal state
+	ctx      context.Context
+	workChan chan DownloadWork
+	errChan  chan error
+	wg       *sync.WaitGroup
+	logger   *slog.Logger // scoped to the upload session
+}
+
+func NewDownloader(config DownloaderConfig, streamer *common.Streamer) *Downloader {
+	return &Downloader{
+		config:   config,
+		streamer: streamer,
+	}
+}
+
+func (d *Downloader) DownloadFile(ctx context.Context, chunkLocations []coordinator.ChunkLocation, sessionID string, totalFileSize int, logger *slog.Logger) (string, error) {
+	// Create temporary file
+	tempFile, err := os.CreateTemp(d.config.TempDir, fmt.Sprintf("download_%s.tmp", sessionID))
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary file: %w", err)
+	}
+
+	// Pre-allocate file size (creates sparse file)
+	if err := tempFile.Truncate(int64(totalFileSize)); err != nil {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+		return "", fmt.Errorf("failed to truncate temp file: %w", err)
+	}
+
+	session := &downloadSession{
+		ctx:          ctx,
+		workChan:     make(chan DownloadWork, d.config.NumWorkers),
+		errChan:      make(chan error, len(chunkLocations)),
+		wg:           &sync.WaitGroup{},
+		logger:       logger,
+		tempFile:     tempFile,
+		tempFileSize: int64(totalFileSize),
+	}
+
+	// Launch N workers for session
+	for i := range d.config.NumWorkers {
+		session.wg.Add(1)
+		go func(workerID int) {
+			defer session.wg.Done()
+			for work := range session.workChan {
+				if err := d.processWork(work, session); err != nil {
+					session.logger.Error(fmt.Sprintf("Worker %d failed", workerID), slog.String("error", err.Error()))
+					session.errChan <- err
+				}
+			}
+		}(i)
+	}
+
+	// Queue work
+	if err := d.queueWork(session, chunkLocations, sessionID, logger); err != nil {
+		tempFile.Close()
+		return "", fmt.Errorf("failed to queue work: %w", err)
+	}
+
+	// Close work channel
+	close(session.workChan)
+
+	// Close error channel when all goroutines complete
+	go func() {
+		session.wg.Wait()
+		close(session.errChan)
+	}()
+
+	select {
+	case err, ok := <-session.errChan:
+		if !ok { // Error channel is closed
+			tempFile.Close()
+			return tempFile.Name(), nil
+		}
+
+		// Return on first error
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+		return "", err
+
+	case <-ctx.Done():
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+		return "", ctx.Err()
+	}
+}
+
+func (d *Downloader) processWork(work DownloadWork, session *downloadSession) error {
+	retryCount := 0
+	for retryCount < d.config.ChunkRetryCount {
+		if err := d.downloadChunk(work, session); err != nil {
+			retryCount++
+			if retryCount >= d.config.ChunkRetryCount {
+				return fmt.Errorf("failed to download chunk %s after %d retries", work.chunkID, retryCount)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d *Downloader) downloadChunk(work DownloadWork, session *downloadSession) error {
+	session.logger.Info("Downloading chunk")
+
+	stream, err := work.client.DownloadChunkStream(session.ctx, common.DownloadStreamRequest{SessionID: work.sessionID})
+	if err != nil {
+		return fmt.Errorf("failed to create download stream: %w", err)
+	}
+
+	buffer := make([]byte, d.streamer.Config.ChunkStreamSize)
+	writer := bytes.NewBuffer(buffer)
+
+	for {
+		protoChunkDataStream, err := stream.Recv()
+		if err != nil {
+			return fmt.Errorf("failed to receive chunk data: %w", err)
+		}
+		chunkStream := common.ChunkDataStreamFromProto(protoChunkDataStream)
+
+		// Write chunk data to buffer
+
+		if _, err := writer.Write(chunkStream.Data); err != nil {
+			session.fileMutex.Unlock()
+			return fmt.Errorf("failed to write chunk data to buffer: %w", err)
+		}
+		session.fileMutex.Unlock()
+
+		if chunkStream.IsFinal {
+			break
+		}
+	}
+
+	// Write buffer to temp file
+	session.fileMutex.Lock()
+	session.tempFile.Seek(int64(0), io.SeekStart) // TODO: placeholder value -- need the chunkIndex and chunkSize to calculate the file offset
+	session.tempFile.Write(writer.Bytes())
+	session.fileMutex.Unlock()
+
+	// if err := d.streamer.StreamChunk(session.ctx, stream, session.logger, common.StreamChunkParams{
+	// 	SessionID: work.sessionID,
+	// 	ChunkMeta: work.chunkMeta,
+	// 	Data:      work.data,
+	// }); err != nil {
+	// 	return fmt.Errorf("failed to stream chunk %s: %w", work.chunkID, err)
+	// }
+
+	return nil
+}
+
+func (d *Downloader) queueWork(session *downloadSession, chunkLocations []coordinator.ChunkLocation, sessionID string, logger *slog.Logger) error {
+	for i, location := range chunkLocations {
+		if err := session.ctx.Err(); err != nil {
+			return err
+		}
+
+		client, err := datanode.NewDataNodeClient(location.Node)
+		if err != nil {
+			return fmt.Errorf("failed to create datanode client: %w", err)
+		}
+
+		downloadChunkResponse, err := client.PrepareChunkDownload(session.ctx, common.DownloadChunkRequest{ChunkID: location.ChunkID})
+		if err != nil {
+			logger.Error("Failed to prepare chunk %s for download: %v", location.ChunkID, err)
+			return fmt.Errorf("failed to prepare chunk %s for download: %v", location.ChunkID, err)
+		}
+
+		if !downloadChunkResponse.Accept {
+			logger.Error("Node did not accept chunk download %s: %s", location.ChunkID, downloadChunkResponse.Message)
+			return fmt.Errorf("node did not accept chunk upload %s: %s", location.ChunkID, downloadChunkResponse.Message)
+		}
+		logger.Info(fmt.Sprintf("Node accepted chunk %s download request", location.ChunkID))
+
+		session.workChan <- DownloadWork{
+			chunkID:    location.ChunkID,
+			chunkIndex: i,
+			client:     client,
+			sessionID:  sessionID,
+			logger:     logger,
+		}
+	}
+
+	return nil
+}

--- a/dfs/internal/client/types.go
+++ b/dfs/internal/client/types.go
@@ -17,5 +17,7 @@ type Client struct {
 
 func NewClient(coordinatorClient *coordinator.CoordinatorClient, logger *slog.Logger) *Client {
 	clientLogger := logging.ExtendLogger(logger, slog.String("component", "client"))
-	return &Client{coordinatorClient: coordinatorClient, streamer: common.NewStreamer(common.DefaultStreamerConfig()), logger: clientLogger}
+	streamer := common.NewStreamer(common.DefaultStreamerConfig())
+	streamer.Config.WaitReplicas = true
+	return &Client{coordinatorClient: coordinatorClient, streamer: streamer, logger: clientLogger}
 }

--- a/dfs/internal/client/types.go
+++ b/dfs/internal/client/types.go
@@ -11,13 +11,15 @@ import (
 // Client performs operations to reach coordinator or data nodes
 type Client struct {
 	coordinatorClient *coordinator.CoordinatorClient
+	uploader          *Uploader
+	downloader        *Downloader
 	streamer          *common.Streamer
 	logger            *slog.Logger
 }
 
-func NewClient(coordinatorClient *coordinator.CoordinatorClient, logger *slog.Logger) *Client {
+func NewClient(coordinatorClient *coordinator.CoordinatorClient, uploader *Uploader, downloader *Downloader, logger *slog.Logger) *Client {
 	clientLogger := logging.ExtendLogger(logger, slog.String("component", "client"))
 	streamer := common.NewStreamer(common.DefaultStreamerConfig())
 	streamer.Config.WaitReplicas = true
-	return &Client{coordinatorClient: coordinatorClient, streamer: streamer, logger: clientLogger}
+	return &Client{coordinatorClient: coordinatorClient, streamer: streamer, logger: clientLogger, uploader: uploader, downloader: downloader}
 }

--- a/dfs/internal/client/uploader.go
+++ b/dfs/internal/client/uploader.go
@@ -1,0 +1,244 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+
+	"github.com/mochivi/distributed-file-system/internal/common"
+	"github.com/mochivi/distributed-file-system/internal/coordinator"
+	"github.com/mochivi/distributed-file-system/internal/datanode"
+)
+
+// chunkInfoMap stores information about each datanode where chunks are stored
+type chunkInfoMap struct {
+	chunkInfos map[string]*common.ChunkInfo
+	mutex      sync.Mutex
+}
+
+func (c *chunkInfoMap) tryAddReplica(chunkID string, replica *common.DataNodeInfo) bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	chunkInfo, ok := c.chunkInfos[chunkID]
+	if !ok {
+		return false
+	}
+	chunkInfo.Replicas = append(chunkInfo.Replicas, replica)
+	return true
+}
+
+func (c *chunkInfoMap) addChunkInfo(chunkInfo *common.ChunkInfo) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.chunkInfos[chunkInfo.ID] = chunkInfo
+}
+
+func (c *chunkInfoMap) getChunkInfos() []common.ChunkInfo {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	chunkInfos := make([]common.ChunkInfo, 0, len(c.chunkInfos))
+	for _, chunkInfo := range c.chunkInfos {
+		chunkInfos = append(chunkInfos, *chunkInfo)
+	}
+	return chunkInfos
+}
+
+// Define the datatype that workers will receive
+type UploaderWork struct {
+	sessionID string
+	chunkMeta common.ChunkMeta
+	data      []byte
+	client    *datanode.DataNodeClient
+}
+
+type UploaderConfig struct {
+	NumWorkers      int
+	ChunkRetryCount int
+}
+
+// Uploads chunks to peer
+type Uploader struct {
+	streamer *common.Streamer
+	config   UploaderConfig
+}
+
+type uploadSession struct {
+	// Input params
+	chunkLocations []coordinator.ChunkLocation
+	chunksize      int
+
+	// Internal state
+	ctx        context.Context
+	workChan   chan UploaderWork
+	errChan    chan error
+	chunkInfos *chunkInfoMap
+	wg         *sync.WaitGroup
+	logger     *slog.Logger // scoped to the upload session
+}
+
+func NewUploader(streamer *common.Streamer, logger *slog.Logger, config UploaderConfig) *Uploader {
+	return &Uploader{
+		streamer: streamer,
+		config:   config,
+	}
+}
+
+func (u *Uploader) UploadFile(ctx context.Context, file *os.File, chunkLocations []coordinator.ChunkLocation, sessionID string, logger *slog.Logger) ([]common.ChunkInfo, error) {
+	session := &uploadSession{
+		ctx:      ctx,
+		workChan: make(chan UploaderWork, u.config.NumWorkers),
+		errChan:  make(chan error, len(chunkLocations)),
+		chunkInfos: &chunkInfoMap{
+			chunkInfos: make(map[string]*common.ChunkInfo, len(chunkLocations)),
+			mutex:      sync.Mutex{},
+		},
+		wg:     &sync.WaitGroup{},
+		logger: logger,
+	}
+
+	// Launch N workers for session
+	for i := range u.config.NumWorkers {
+		session.wg.Add(1)
+		go func(workerID int) {
+			defer session.wg.Done()
+			for work := range session.workChan {
+				if err := u.processWork(work, session); err != nil {
+					session.logger.Error(fmt.Sprintf("Worker %d failed", workerID), slog.String("error", err.Error()))
+					session.errChan <- err
+				}
+			}
+		}(i)
+	}
+
+	// Queue work
+	if err := u.QueueWork(ctx, session, file, session.chunksize); err != nil {
+		return nil, fmt.Errorf("failed to queue work: %w", err)
+	}
+
+	close(session.workChan)
+
+	// Close error channel when all goroutines complete
+	// Looks a bit odd to wg.Wait inside a goroutine but the ErrChan blocks until its closed below
+	go func() {
+		session.wg.Wait()
+		close(session.errChan)
+	}()
+
+	// Currently, returning on exactly the first error received
+	for err := range session.errChan {
+		if err != nil {
+			session.logger.Error("Error in worker", slog.String("error", err.Error()))
+			return nil, err
+		}
+	}
+
+	// Now, we need to confirm the upload to the coordinator, so that the metadata is updated
+	// This is done by sending a ConfirmUploadRequest to the coordinator
+	chunkInfos := session.chunkInfos.getChunkInfos()
+
+	return chunkInfos, nil
+}
+
+func (u *Uploader) processWork(work UploaderWork, session *uploadSession) error {
+	retryCount := 0
+	for retryCount < u.config.ChunkRetryCount {
+		if err := u.uploadChunk(work, session); err != nil {
+			retryCount++
+			if retryCount >= u.config.ChunkRetryCount {
+				return fmt.Errorf("failed to store chunk %s after %d retries", work.chunkMeta.ChunkID, retryCount)
+			}
+		} else {
+			break
+		}
+	}
+
+	// Update chunk infos - this information is sent to the coordinator to update the metadata about the chunk
+	// Try to add a replica, if that is unsucessful, we need to first add an entire chunkInfo
+	if ok := session.chunkInfos.tryAddReplica(work.chunkMeta.ChunkID, work.client.Node); !ok {
+		session.chunkInfos.addChunkInfo(&common.ChunkInfo{
+			ID:       work.chunkMeta.ChunkID,
+			Checksum: work.chunkMeta.Checksum,
+			Size:     work.chunkMeta.ChunkSize,
+			Replicas: []*common.DataNodeInfo{work.client.Node},
+		})
+	}
+
+	return nil
+}
+
+func (u *Uploader) uploadChunk(work UploaderWork, session *uploadSession) error {
+	session.logger.Info("Streaming chunk")
+
+	// Open stream to send chunk data to the datanode
+	stream, err := work.client.UploadChunkStream(session.ctx)
+	if err != nil {
+		session.logger.Error("Failed to create upload stream")
+		return fmt.Errorf("failed to create stream for chunk %s: %w", work.chunkMeta.ChunkID, err)
+	}
+
+	// Stream chunk to peer
+	if err := u.streamer.StreamChunk(session.ctx, stream, session.logger, common.StreamChunkParams{
+		SessionID: work.sessionID, // This sessionID is the streaming sessionID, NOT the metadata sessionID or uploadSessionID
+		ChunkMeta: work.chunkMeta,
+		Data:      work.data,
+	}); err != nil {
+		session.logger.Error("Failed to create upload stream")
+		return fmt.Errorf("failed to stream chunk %s: %w", work.chunkMeta.ChunkID, err)
+	}
+
+	session.logger.Info("Chunk streaming completed")
+
+	return nil
+}
+
+// Reads file and queue work
+func (u *Uploader) QueueWork(ctx context.Context, session *uploadSession, file *os.File, chunksize int) error {
+	for i, chunkUploadLocation := range session.chunkLocations {
+		chunkData := make([]byte, chunksize)
+		n, err := file.Read(chunkData)
+		if err != nil && err != io.EOF {
+			close(session.workChan)
+			session.logger.Error("Failed to read chunk", slog.Int("chunk_index", i), slog.String("error", err.Error()))
+			return fmt.Errorf("failed to read chunk %d: %w", i, err)
+		}
+		chunkData = chunkData[:n]
+
+		checksum := common.CalculateChecksum(chunkData)
+		chunkMeta := common.ChunkMeta{
+			ChunkID:   chunkUploadLocation.ChunkID,
+			ChunkSize: len(chunkData),
+			Checksum:  checksum,
+		}
+
+		client, err := datanode.NewDataNodeClient(chunkUploadLocation.Node)
+		if err != nil {
+			session.logger.Error("Failed to create connection to datanode client", slog.String("error", err.Error()))
+			return fmt.Errorf("failed to create connection to datanode client: %w", err)
+		}
+
+		// Check if client accepts to store the chunk
+		storeChunkResponse, err := client.StoreChunk(ctx, chunkMeta)
+		if err != nil {
+			session.logger.Error("Failed to prepare chunk %s for upload: %w", chunkMeta.ChunkID, err)
+			return fmt.Errorf("failed to prepare chunk %s for upload: %w", chunkMeta.ChunkID, err)
+		}
+
+		if !storeChunkResponse.Accept {
+			session.logger.Error("Node did not accept chunk upload %s: %s", chunkMeta.ChunkID, storeChunkResponse.Message)
+			return fmt.Errorf("node did not accept chunk upload %s: %s", chunkMeta.ChunkID, storeChunkResponse.Message)
+		}
+		session.logger.Info("Chunk accepted", slog.String("chunk_id", chunkMeta.ChunkID))
+
+		session.workChan <- UploaderWork{
+			sessionID: storeChunkResponse.SessionID, // streaming sessionID, NOT metadata sessionID
+			chunkMeta: chunkMeta,
+			data:      chunkData,
+			client:    client,
+		}
+	}
+
+	return nil
+}

--- a/dfs/internal/common/node_manager.go
+++ b/dfs/internal/common/node_manager.go
@@ -160,17 +160,19 @@ func (m *NodeManager) SelectBestNodes(n int, self ...string) ([]*DataNodeInfo, e
 }
 
 // Retrieves which nodes have some chunk
-func (m *NodeManager) GetAvailableNodeForChunk(replicaIDs []*DataNodeInfo) (*DataNodeInfo, bool) {
+// TODO: implement a check with the data nodes to see if they have the chunk before adding
+func (m *NodeManager) GetAvailableNodesForChunk(replicaIDs []*DataNodeInfo) ([]*DataNodeInfo, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	nodes := make([]*DataNodeInfo, 0, len(replicaIDs))
 	for _, replica := range replicaIDs {
 		if node, exists := m.nodes[replica.ID]; exists && node.Status == NodeHealthy {
-			return node, true
+			nodes = append(nodes, node)
 		}
 	}
 
-	return nil, false
+	return nodes, len(nodes) > 0
 }
 
 // addToHistory adds an update to the circular buffer

--- a/dfs/internal/common/requests.go
+++ b/dfs/internal/common/requests.go
@@ -2,29 +2,22 @@ package common
 
 import "github.com/mochivi/distributed-file-system/pkg/proto"
 
-// Coordinates the chunk upload process, if propagate is true, the peer must replicate the chunk to other nodes
-type ChunkMeta struct {
-	ChunkID   string
-	ChunkSize int
-	Checksum  string
+type UploadChunkRequest struct {
+	ChunkInfo ChunkInfo
 	Propagate bool
 }
 
-func ChunkMetaFromProto(pb *proto.ChunkMeta) ChunkMeta {
-	return ChunkMeta{
-		ChunkID:   pb.ChunkId,
-		ChunkSize: int(pb.ChunkSize),
-		Checksum:  pb.Checksum,
+func UploadChunkRequestFromProto(pb *proto.UploadChunkRequest) UploadChunkRequest {
+	return UploadChunkRequest{
+		ChunkInfo: ChunkInfoFromProto(pb.ChunkInfo),
 		Propagate: pb.Propagate,
 	}
 }
 
-func (cm ChunkMeta) ToProto() *proto.ChunkMeta {
-	return &proto.ChunkMeta{
-		ChunkId:   cm.ChunkID,
-		ChunkSize: int64(cm.ChunkSize),
-		Checksum:  cm.Checksum,
-		Propagate: cm.Propagate,
+func (ucr UploadChunkRequest) ToProto() *proto.UploadChunkRequest {
+	return &proto.UploadChunkRequest{
+		ChunkInfo: ucr.ChunkInfo.ToProto(),
+		Propagate: ucr.Propagate,
 	}
 }
 

--- a/dfs/internal/common/requests.go
+++ b/dfs/internal/common/requests.go
@@ -29,56 +29,49 @@ func (cm ChunkMeta) ToProto() *proto.ChunkMeta {
 }
 
 // Coordinates the chunk upload process, if accept is true, the peer can start streaming the chunk data
-type ChunkUploadReady struct {
+type NodeReady struct {
 	Accept    bool
 	Message   string
 	SessionID string
 }
 
-func ChunkUploadReadyFromProto(pb *proto.ChunkUploadReady) ChunkUploadReady {
-	return ChunkUploadReady{
+func NodeReadyFromProto(pb *proto.NodeReady) NodeReady {
+	return NodeReady{
 		Accept:    pb.Accept,
 		Message:   pb.Message,
 		SessionID: pb.SessionId,
 	}
 }
 
-func (cuu ChunkUploadReady) ToProto() *proto.ChunkUploadReady {
-	return &proto.ChunkUploadReady{
+func (cuu NodeReady) ToProto() *proto.NodeReady {
+	return &proto.NodeReady{
 		Accept:    cuu.Accept,
 		Message:   cuu.Message,
 		SessionId: cuu.SessionID,
 	}
 }
 
-type RetrieveChunkRequest struct {
+type DownloadChunkRequest struct {
 	ChunkID string
 }
 
-func RetrieveChunkRequestFromProto(pb *proto.RetrieveChunkRequest) RetrieveChunkRequest {
-	return RetrieveChunkRequest{ChunkID: pb.ChunkId}
+func DownloadChunkRequestFromProto(pb *proto.DownloadChunkRequest) DownloadChunkRequest {
+	return DownloadChunkRequest{ChunkID: pb.ChunkId}
 }
-func (rtr RetrieveChunkRequest) ToProto() *proto.RetrieveChunkRequest {
-	return &proto.RetrieveChunkRequest{ChunkId: rtr.ChunkID}
-}
-
-type RetrieveChunkResponse struct {
-	Data     []byte
-	Checksum string
+func (r DownloadChunkRequest) ToProto() *proto.DownloadChunkRequest {
+	return &proto.DownloadChunkRequest{ChunkId: r.ChunkID}
 }
 
-func RetrieveChunkResponseFromProto(pb *proto.RetrieveChunkResponse) RetrieveChunkResponse {
-	return RetrieveChunkResponse{
-		Data:     pb.Data,
-		Checksum: pb.Checksum,
-	}
+type DownloadStreamRequest struct {
+	SessionID string
 }
 
-func (rcr RetrieveChunkResponse) ToProto() *proto.RetrieveChunkResponse {
-	return &proto.RetrieveChunkResponse{
-		Data:     rcr.Data,
-		Checksum: rcr.Checksum,
-	}
+func DownloadStreamRequestFromProto(pb *proto.DownloadStreamRequest) DownloadStreamRequest {
+	return DownloadStreamRequest{SessionID: pb.SessionId}
+}
+
+func (r DownloadStreamRequest) ToProto() *proto.DownloadStreamRequest {
+	return &proto.DownloadStreamRequest{SessionId: r.SessionID}
 }
 
 type DeleteChunkRequest struct {

--- a/dfs/internal/common/requests.go
+++ b/dfs/internal/common/requests.go
@@ -168,25 +168,37 @@ type ChunkDataAck struct {
 	Message       string
 	BytesReceived int
 	ReadyForNext  bool
+	Replicas      []*DataNodeInfo
 }
 
 func ChunkDataAckFromProto(pb *proto.ChunkDataAck) ChunkDataAck {
+	replicas := make([]*DataNodeInfo, len(pb.Replicas))
+	for i, replica := range pb.Replicas {
+		replicaInfo := DataNodeInfoFromProto(replica)
+		replicas[i] = &replicaInfo
+	}
 	return ChunkDataAck{
 		SessionID:     pb.SessionId,
 		Success:       pb.Success,
 		Message:       pb.Message,
 		BytesReceived: int(pb.BytesReceived),
 		ReadyForNext:  pb.ReadyForNext,
+		Replicas:      replicas,
 	}
 }
 
 func (cda ChunkDataAck) ToProto() *proto.ChunkDataAck {
+	replicas := make([]*proto.DataNodeInfo, len(cda.Replicas))
+	for i, replica := range cda.Replicas {
+		replicas[i] = replica.ToProto()
+	}
 	return &proto.ChunkDataAck{
 		SessionId:     cda.SessionID,
 		Success:       cda.Success,
 		Message:       cda.Message,
 		BytesReceived: int64(cda.BytesReceived),
 		ReadyForNext:  cda.ReadyForNext,
+		Replicas:      replicas,
 	}
 }
 

--- a/dfs/internal/common/streamer.go
+++ b/dfs/internal/common/streamer.go
@@ -38,7 +38,7 @@ type StreamChunkParams struct {
 	SessionID string
 
 	// Chunk data
-	ChunkMeta ChunkMeta
+	ChunkInfo ChunkInfo
 	Data      []byte
 }
 
@@ -83,7 +83,7 @@ func (s *Streamer) StreamChunk(ctx context.Context, stream grpc.BidiStreamingCli
 			// Create stream message
 			streamMsg := &ChunkDataStream{
 				SessionID:       params.SessionID,
-				ChunkID:         params.ChunkMeta.ChunkID,
+				ChunkID:         params.ChunkInfo.ID,
 				Data:            chunkData,
 				Offset:          offset,
 				IsFinal:         isFinal,
@@ -172,9 +172,9 @@ func (s *Streamer) StreamChunk(ctx context.Context, stream grpc.BidiStreamingCli
 
 	// Validate if checksum after all partial sections are added up still matches the original
 	calculatedChecksum := fmt.Sprintf("%x", hasher.Sum(nil))
-	if calculatedChecksum != params.ChunkMeta.Checksum {
+	if calculatedChecksum != params.ChunkInfo.Checksum {
 		return fmt.Errorf("request checksum mismatch: expected %s, calculated %s",
-			params.ChunkMeta.Checksum, calculatedChecksum)
+			params.ChunkInfo.Checksum, calculatedChecksum)
 	}
 
 	if !finalAck.Success {

--- a/dfs/internal/common/types.go
+++ b/dfs/internal/common/types.go
@@ -62,6 +62,7 @@ func (fi FileInfo) ToProto() *proto.FileInfo {
 // ChunkInfo + proto conversions
 type ChunkInfo struct {
 	ID       string
+	Index    int // Index of the chunk in the file
 	Size     int
 	Replicas []*DataNodeInfo // DataNode IDs storing this chunk
 	Checksum string

--- a/dfs/internal/common/types.go
+++ b/dfs/internal/common/types.go
@@ -59,26 +59,44 @@ func (fi FileInfo) ToProto() *proto.FileInfo {
 	}
 }
 
-// ChunkInfo + proto conversions
-type ChunkInfo struct {
+// ChunkHeader + proto conversions
+type ChunkHeader struct {
 	ID       string
+	Version  byte
 	Index    int // Index of the chunk in the file
-	Size     int
-	Replicas []*DataNodeInfo // DataNode IDs storing this chunk
+	Size     int64
 	Checksum string
 }
 
-func ChunkInfoFromProto(pb *proto.ChunkInfo) ChunkInfo {
-	replicas := make([]*DataNodeInfo, 0, len(pb.Replicas))
-	for _, replica := range pb.Replicas {
-		nodeInfo := DataNodeInfoFromProto(replica)
-		replicas = append(replicas, &nodeInfo)
-	}
-	return ChunkInfo{
+func ChunkHeaderFromProto(pb *proto.ChunkHeader) ChunkHeader {
+	return ChunkHeader{
 		ID:       pb.Id,
-		Size:     int(pb.Size),
-		Replicas: replicas,
+		Version:  byte(pb.Version),
+		Index:    int(pb.Index),
+		Size:     pb.Size,
 		Checksum: pb.Checksum,
+	}
+}
+
+func (ch ChunkHeader) ToProto() *proto.ChunkHeader {
+	return &proto.ChunkHeader{
+		Id:       ch.ID,
+		Version:  uint32(ch.Version),
+		Index:    int32(ch.Index),
+		Size:     ch.Size,
+		Checksum: ch.Checksum,
+	}
+}
+
+type ChunkInfo struct {
+	Header   ChunkHeader
+	Replicas []*DataNodeInfo // DataNode IDs storing this chunk
+}
+
+func ChunkInfoFromProto(pb *proto.ChunkInfo) ChunkInfo {
+	return ChunkInfo{
+		Header:   ChunkHeaderFromProto(pb.Header),
+		Replicas: make([]*DataNodeInfo, 0, len(pb.Replicas)),
 	}
 }
 
@@ -88,10 +106,8 @@ func (ci ChunkInfo) ToProto() *proto.ChunkInfo {
 		protoReplicas = append(protoReplicas, replica.ToProto())
 	}
 	return &proto.ChunkInfo{
-		Id:       ci.ID,
-		Size:     int64(ci.Size),
+		Header:   ci.Header.ToProto(),
 		Replicas: protoReplicas,
-		Checksum: ci.Checksum,
 	}
 }
 

--- a/dfs/internal/coordinator/metadata.go
+++ b/dfs/internal/coordinator/metadata.go
@@ -43,14 +43,16 @@ func newMetadataUploadSession(sessionID string, exp time.Duration, fileInfo *com
 
 func (m *metadataManager) trackUpload(sessionID string, req UploadRequest, numChunks int) {
 	// Create chunk info array
-	chunks := make([]common.ChunkInfo, numChunks)
+	chunkInfos := make([]common.ChunkInfo, numChunks)
 	for i := 0; i < numChunks; i++ {
 		chunkID := common.FormatChunkID(req.Path, i)
-		chunks[i] = common.ChunkInfo{
-			ID:       chunkID,
-			Size:     0,   // Will be updated when chunk is stored
+		chunkInfos[i] = common.ChunkInfo{
+			Header: common.ChunkHeader{
+				ID:       chunkID,
+				Size:     0,  // Will be updated when chunk is stored
+				Checksum: "", // Will be updated when chunk is stored
+			},
 			Replicas: nil, // Will be updated when replicas are created
-			Checksum: "",  // Will be updated when chunk is stored
 		}
 	}
 
@@ -58,7 +60,7 @@ func (m *metadataManager) trackUpload(sessionID string, req UploadRequest, numCh
 		Path:       req.Path,
 		Size:       req.Size,
 		ChunkCount: numChunks,
-		Chunks:     chunks,
+		Chunks:     chunkInfos,
 		CreatedAt:  time.Now(),
 		Checksum:   req.Checksum,
 	}

--- a/dfs/internal/coordinator/requests.go
+++ b/dfs/internal/coordinator/requests.go
@@ -71,8 +71,9 @@ func (dr DownloadRequest) ToProto() *proto.DownloadRequest {
 }
 
 type DownloadResponse struct {
-	fileInfo       common.FileInfo
-	chunkLocations []ChunkLocation
+	FileInfo       common.FileInfo
+	ChunkLocations []ChunkLocation
+	SessionID      string
 }
 
 func DownloadResponseFromProto(pb *proto.DownloadResponse) DownloadResponse {
@@ -81,19 +82,21 @@ func DownloadResponseFromProto(pb *proto.DownloadResponse) DownloadResponse {
 		chunkLocations = append(chunkLocations, ChunkLocationFromProto(chunkLocation))
 	}
 	return DownloadResponse{
-		fileInfo:       common.FileInfoFromProto(pb.FileInfo),
-		chunkLocations: chunkLocations,
+		FileInfo:       common.FileInfoFromProto(pb.FileInfo),
+		ChunkLocations: chunkLocations,
+		SessionID:      pb.SessionId,
 	}
 }
 
 func (dr DownloadResponse) ToProto() *proto.DownloadResponse {
-	protoChunkLocations := make([]*proto.ChunkLocation, len(dr.chunkLocations))
-	for _, item := range dr.chunkLocations {
+	protoChunkLocations := make([]*proto.ChunkLocation, len(dr.ChunkLocations))
+	for _, item := range dr.ChunkLocations {
 		protoChunkLocations = append(protoChunkLocations, item.ToProto())
 	}
 	return &proto.DownloadResponse{
-		FileInfo:       dr.fileInfo.ToProto(),
+		FileInfo:       dr.FileInfo.ToProto(),
 		ChunkLocations: protoChunkLocations,
+		SessionId:      dr.SessionID,
 	}
 }
 

--- a/dfs/internal/coordinator/server.go
+++ b/dfs/internal/coordinator/server.go
@@ -80,12 +80,12 @@ func (c *Coordinator) DownloadFile(ctx context.Context, req *proto.DownloadReque
 	for i, chunk := range fileInfo.Chunks {
 		node, ok := c.nodeManager.GetAvailableNodeForChunk(chunk.Replicas)
 		if !ok {
-			c.logger.Error("Failed to get available node for chunk", slog.String("chunk_id", chunk.ID), slog.String("file_path", req.Path))
+			c.logger.Error("Failed to get available node for chunk", slog.String("chunk_id", chunk.Header.ID), slog.String("file_path", req.Path))
 			return nil, status.Error(codes.NotFound, "no available nodes")
 		}
 
 		chunkLocations[i] = ChunkLocation{
-			ChunkID: chunk.ID,
+			ChunkID: chunk.Header.ID,
 			Node:    node,
 		}
 	}

--- a/dfs/internal/coordinator/server.go
+++ b/dfs/internal/coordinator/server.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"math/rand"
 
@@ -28,7 +29,7 @@ func (c *Coordinator) UploadFile(ctx context.Context, pb *proto.UploadRequest) (
 		chunkSize = c.config.ChunkSize * 1024 * 1024
 	}
 	numChunks := (req.Size + chunkSize - 1) / chunkSize
-	c.logger.Debug("File will be split into chunks", slog.Int("num_chunks", numChunks), slog.Int("chunk_size", chunkSize/(1024*1024)))
+	c.logger.Debug(fmt.Sprintf("File will be split into %d chunks of %dMB", numChunks, chunkSize/(1024*1024)))
 
 	// Get a list of the best nodes to upload to
 	nodes, err := c.nodeManager.SelectBestNodes(numChunks)

--- a/dfs/internal/coordinator/server.go
+++ b/dfs/internal/coordinator/server.go
@@ -92,8 +92,9 @@ func (c *Coordinator) DownloadFile(ctx context.Context, req *proto.DownloadReque
 
 	c.logger.Debug("Replying to client with chunk locations", slog.Int("num_chunks", len(chunkLocations)))
 	return DownloadResponse{
-		fileInfo:       *fileInfo,
-		chunkLocations: chunkLocations,
+		FileInfo:       *fileInfo,
+		ChunkLocations: chunkLocations,
+		SessionID:      uuid.NewString(), // TODO: this should be a session id that is used to track the download
 	}.ToProto(), nil
 }
 

--- a/dfs/internal/coordinator/types.go
+++ b/dfs/internal/coordinator/types.go
@@ -39,20 +39,28 @@ func NewCoordinator(cfg CoordinatorConfig, metaStore storage.MetadataStore, meta
 // ChunkLocation represents where some chunk should be stored (primary node + endpoint)
 type ChunkLocation struct {
 	ChunkID string
-	Node    *common.DataNodeInfo
+	Nodes   []*common.DataNodeInfo
 }
 
 func ChunkLocationFromProto(pb *proto.ChunkLocation) ChunkLocation {
-	node := common.DataNodeInfoFromProto(pb.Node)
+	nodes := make([]*common.DataNodeInfo, 0, len(pb.Nodes))
+	for _, node := range pb.Nodes {
+		nodeInfo := common.DataNodeInfoFromProto(node)
+		nodes = append(nodes, &nodeInfo)
+	}
 	return ChunkLocation{
 		ChunkID: pb.ChunkId,
-		Node:    &node,
+		Nodes:   nodes,
 	}
 }
 
 func (cs *ChunkLocation) ToProto() *proto.ChunkLocation {
+	nodes := make([]*proto.DataNodeInfo, 0, len(cs.Nodes))
+	for _, node := range cs.Nodes {
+		nodes = append(nodes, node.ToProto())
+	}
 	return &proto.ChunkLocation{
 		ChunkId: cs.ChunkID,
-		Node:    cs.Node.ToProto(),
+		Nodes:   nodes,
 	}
 }

--- a/dfs/internal/datanode/client.go
+++ b/dfs/internal/datanode/client.go
@@ -10,11 +10,11 @@ import (
 
 // client -> node
 // This is the primary node that is receiving the chunk
-func (c *DataNodeClient) StoreChunk(ctx context.Context, req common.ChunkInfo, opts ...grpc.CallOption) (common.NodeReady, error) {
+func (c *DataNodeClient) StoreChunk(ctx context.Context, req common.ChunkHeader, opts ...grpc.CallOption) (common.NodeReady, error) {
 	// Convert to expected request type
 	uploadChunkRequest := common.UploadChunkRequest{
-		ChunkInfo: req,
-		Propagate: true, // StoreChunk is always propagated
+		ChunkHeader: req,
+		Propagate:   true, // StoreChunk is always propagated
 	}
 
 	resp, err := c.client.PrepareChunkUpload(ctx, uploadChunkRequest.ToProto(), opts...)
@@ -26,13 +26,13 @@ func (c *DataNodeClient) StoreChunk(ctx context.Context, req common.ChunkInfo, o
 }
 
 // client -> node
-func (c *DataNodeClient) PrepareChunkDownload(ctx context.Context, req common.DownloadChunkRequest, opts ...grpc.CallOption) (common.NodeReady, error) {
+func (c *DataNodeClient) PrepareChunkDownload(ctx context.Context, req common.DownloadChunkRequest, opts ...grpc.CallOption) (common.DownloadReady, error) {
 	resp, err := c.client.PrepareChunkDownload(ctx, req.ToProto(), opts...)
 	if err != nil {
 		err = handlegRPCError(err, req.ChunkID)
-		return common.NodeReady{}, err
+		return common.DownloadReady{}, err
 	}
-	return common.NodeReadyFromProto(resp), nil
+	return common.DownloadReadyFromProto(resp), nil
 }
 
 // client -> node
@@ -48,10 +48,10 @@ func (c *DataNodeClient) DeleteChunk(ctx context.Context, req common.DeleteChunk
 // node -> node
 // This is a replica node that is receiving the chunk
 // This is a copy of StoreChunk, but with a different method name
-func (c *DataNodeClient) ReplicateChunk(ctx context.Context, req common.ChunkInfo, opts ...grpc.CallOption) (common.NodeReady, error) {
+func (c *DataNodeClient) ReplicateChunk(ctx context.Context, req common.ChunkHeader, opts ...grpc.CallOption) (common.NodeReady, error) {
 	uploadChunkRequest := common.UploadChunkRequest{
-		ChunkInfo: req,
-		Propagate: false, // ReplicateChunk is not propagated, as it is already received by a replica node
+		ChunkHeader: req,
+		Propagate:   false, // ReplicateChunk is not propagated, as it is already received by a replica node
 	}
 
 	resp, err := c.client.PrepareChunkUpload(ctx, uploadChunkRequest.ToProto(), opts...)

--- a/dfs/internal/datanode/client.go
+++ b/dfs/internal/datanode/client.go
@@ -10,10 +10,16 @@ import (
 
 // client -> node
 // This is the primary node that is receiving the chunk
-func (c *DataNodeClient) StoreChunk(ctx context.Context, req common.ChunkMeta, opts ...grpc.CallOption) (common.NodeReady, error) {
-	resp, err := c.client.PrepareChunkUpload(ctx, req.ToProto(), opts...)
+func (c *DataNodeClient) StoreChunk(ctx context.Context, req common.ChunkInfo, opts ...grpc.CallOption) (common.NodeReady, error) {
+	// Convert to expected request type
+	uploadChunkRequest := common.UploadChunkRequest{
+		ChunkInfo: req,
+		Propagate: true, // StoreChunk is always propagated
+	}
+
+	resp, err := c.client.PrepareChunkUpload(ctx, uploadChunkRequest.ToProto(), opts...)
 	if err != nil {
-		err = handlegRPCError(err, req.ChunkID)
+		err = handlegRPCError(err, req.ID)
 		return common.NodeReady{}, err
 	}
 	return common.NodeReadyFromProto(resp), nil
@@ -42,10 +48,15 @@ func (c *DataNodeClient) DeleteChunk(ctx context.Context, req common.DeleteChunk
 // node -> node
 // This is a replica node that is receiving the chunk
 // This is a copy of StoreChunk, but with a different method name
-func (c *DataNodeClient) ReplicateChunk(ctx context.Context, req common.ChunkMeta, opts ...grpc.CallOption) (common.NodeReady, error) {
-	resp, err := c.client.PrepareChunkUpload(ctx, req.ToProto(), opts...)
+func (c *DataNodeClient) ReplicateChunk(ctx context.Context, req common.ChunkInfo, opts ...grpc.CallOption) (common.NodeReady, error) {
+	uploadChunkRequest := common.UploadChunkRequest{
+		ChunkInfo: req,
+		Propagate: false, // ReplicateChunk is not propagated, as it is already received by a replica node
+	}
+
+	resp, err := c.client.PrepareChunkUpload(ctx, uploadChunkRequest.ToProto(), opts...)
 	if err != nil {
-		err = handlegRPCError(err, req.ChunkID)
+		err = handlegRPCError(err, req.ID)
 		return common.NodeReady{}, err
 	}
 	return common.NodeReadyFromProto(resp), nil

--- a/dfs/internal/datanode/client.go
+++ b/dfs/internal/datanode/client.go
@@ -10,23 +10,23 @@ import (
 
 // client -> node
 // This is the primary node that is receiving the chunk
-func (c *DataNodeClient) StoreChunk(ctx context.Context, req common.ChunkMeta, opts ...grpc.CallOption) (common.ChunkUploadReady, error) {
+func (c *DataNodeClient) StoreChunk(ctx context.Context, req common.ChunkMeta, opts ...grpc.CallOption) (common.NodeReady, error) {
 	resp, err := c.client.PrepareChunkUpload(ctx, req.ToProto(), opts...)
 	if err != nil {
 		err = handlegRPCError(err, req.ChunkID)
-		return common.ChunkUploadReady{}, err
+		return common.NodeReady{}, err
 	}
-	return common.ChunkUploadReadyFromProto(resp), nil
+	return common.NodeReadyFromProto(resp), nil
 }
 
 // client -> node
-func (c *DataNodeClient) RetrieveChunk(ctx context.Context, req common.RetrieveChunkRequest, opts ...grpc.CallOption) (common.RetrieveChunkResponse, error) {
-	resp, err := c.client.RetrieveChunk(ctx, req.ToProto(), opts...)
+func (c *DataNodeClient) PrepareChunkDownload(ctx context.Context, req common.DownloadChunkRequest, opts ...grpc.CallOption) (common.NodeReady, error) {
+	resp, err := c.client.PrepareChunkDownload(ctx, req.ToProto(), opts...)
 	if err != nil {
 		err = handlegRPCError(err, req.ChunkID)
-		return common.RetrieveChunkResponse{}, err
+		return common.NodeReady{}, err
 	}
-	return common.RetrieveChunkResponseFromProto(resp), nil
+	return common.NodeReadyFromProto(resp), nil
 }
 
 // client -> node
@@ -42,18 +42,23 @@ func (c *DataNodeClient) DeleteChunk(ctx context.Context, req common.DeleteChunk
 // node -> node
 // This is a replica node that is receiving the chunk
 // This is a copy of StoreChunk, but with a different method name
-func (c *DataNodeClient) ReplicateChunk(ctx context.Context, req common.ChunkMeta, opts ...grpc.CallOption) (common.ChunkUploadReady, error) {
+func (c *DataNodeClient) ReplicateChunk(ctx context.Context, req common.ChunkMeta, opts ...grpc.CallOption) (common.NodeReady, error) {
 	resp, err := c.client.PrepareChunkUpload(ctx, req.ToProto(), opts...)
 	if err != nil {
 		err = handlegRPCError(err, req.ChunkID)
-		return common.ChunkUploadReady{}, err
+		return common.NodeReady{}, err
 	}
-	return common.ChunkUploadReadyFromProto(resp), nil
+	return common.NodeReadyFromProto(resp), nil
 }
 
 // node -> node
-func (c *DataNodeClient) StreamChunk(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[proto.ChunkDataStream, proto.ChunkDataAck], error) {
-	return c.client.StreamChunk(ctx, opts...)
+func (c *DataNodeClient) UploadChunkStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[proto.ChunkDataStream, proto.ChunkDataAck], error) {
+	return c.client.UploadChunkStream(ctx, opts...)
+}
+
+// node -> node
+func (c *DataNodeClient) DownloadChunkStream(ctx context.Context, req common.DownloadStreamRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[proto.ChunkDataStream], error) {
+	return c.client.DownloadChunkStream(ctx, req.ToProto(), opts...)
 }
 
 // node -> node

--- a/dfs/internal/datanode/config.go
+++ b/dfs/internal/datanode/config.go
@@ -42,7 +42,7 @@ func DefaultDatanodeConfig() DataNodeConfig {
 		},
 
 		Replication: ReplicateManagerConfig{
-			ReplicateTimeout: 2 * time.Minute,
+			ReplicateTimeout: 10 * time.Minute,
 		},
 	}
 }

--- a/dfs/internal/datanode/replication.go
+++ b/dfs/internal/datanode/replication.go
@@ -123,7 +123,7 @@ func (rm *ReplicationManager) replicate(ctx context.Context, client *DataNodeCli
 	clientLogger.Debug("Replication request accepted")
 
 	// Create stream to send the chunk data
-	stream, err := client.StreamChunk(ctx)
+	stream, err := client.UploadChunkStream(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create stream for chunk %s: %v", chunkMeta.ChunkID, err)
 	}

--- a/dfs/internal/datanode/resources.go
+++ b/dfs/internal/datanode/resources.go
@@ -2,6 +2,6 @@ package datanode
 
 // System resources management
 
-func (s *DataNodeServer) hasCapacity(chunkSize int) bool {
+func (s *DataNodeServer) hasCapacity(chunkSize int64) bool {
 	return true
 }

--- a/dfs/internal/datanode/session.go
+++ b/dfs/internal/datanode/session.go
@@ -112,7 +112,7 @@ func (s *DataNodeServer) createStreamingSession(sessionId string, chunkHeader co
 		SessionID:       sessionId,
 		ChunkHeader:     chunkHeader,
 		CreatedAt:       time.Now(),
-		ExpiresAt:       time.Now().Add(s.Config.Session.SessionTimeout),
+		ExpiresAt:       time.Now().Add(s.Config.Session.SessionTimeout), // How much the client has until they submit a request initiating the streaming session
 		Propagate:       propagate,
 		Status:          SessionActive,
 		RunningChecksum: sha256.New(),

--- a/dfs/internal/datanode/session.go
+++ b/dfs/internal/datanode/session.go
@@ -86,11 +86,23 @@ func (sm *SessionManager) Delete(sessionID string) {
 // Temporary solution to check if a chunk is already being streamed, stops duplicate requests
 func (sm *SessionManager) ExistsForChunk(chunkID string) bool {
 	for _, session := range sm.sessions {
-		if session.ChunkHeader.ID == chunkID {
+		if session.ChunkHeader.ID == chunkID && session.Status == SessionActive {
 			return true
 		}
 	}
 	return false
+}
+
+func (sm *SessionManager) LoadByChunk(chunkID string) (*StreamingSession, bool) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	for _, session := range sm.sessions {
+		if session.ChunkHeader.ID == chunkID {
+			return session, true
+		}
+	}
+	return nil, false
 }
 
 // DataNode creates and stores a session

--- a/dfs/internal/datanode/session.go
+++ b/dfs/internal/datanode/session.go
@@ -35,7 +35,7 @@ type StreamingSession struct {
 	ExpiresAt time.Time
 
 	// Chunk metadata
-	common.ChunkInfo
+	common.ChunkHeader
 	Propagate bool
 
 	// Runtime state
@@ -59,8 +59,8 @@ func (sm *SessionManager) Store(sessionID string, session *StreamingSession) err
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 
-	if sm.ExistsForChunk(session.ChunkInfo.ID) {
-		return fmt.Errorf("session for chunk %s already exists", session.ChunkInfo.ID)
+	if sm.ExistsForChunk(session.ChunkHeader.ID) {
+		return fmt.Errorf("session for chunk %s already exists", session.ChunkHeader.ID)
 	}
 
 	sm.sessions[sessionID] = session
@@ -86,7 +86,7 @@ func (sm *SessionManager) Delete(sessionID string) {
 // Temporary solution to check if a chunk is already being streamed, stops duplicate requests
 func (sm *SessionManager) ExistsForChunk(chunkID string) bool {
 	for _, session := range sm.sessions {
-		if session.ChunkInfo.ID == chunkID {
+		if session.ChunkHeader.ID == chunkID {
 			return true
 		}
 	}
@@ -94,11 +94,11 @@ func (sm *SessionManager) ExistsForChunk(chunkID string) bool {
 }
 
 // DataNode creates and stores a session
-func (s *DataNodeServer) createStreamingSession(sessionId string, chunkInfo common.ChunkInfo, propagate bool, logger *slog.Logger) error {
+func (s *DataNodeServer) createStreamingSession(sessionId string, chunkHeader common.ChunkHeader, propagate bool, logger *slog.Logger) error {
 	streamLogger := logging.OperationLogger(logger, "chunk_streaming_session", slog.String("session_id", sessionId))
 	session := &StreamingSession{
 		SessionID:       sessionId,
-		ChunkInfo:       chunkInfo,
+		ChunkHeader:     chunkHeader,
 		CreatedAt:       time.Now(),
 		ExpiresAt:       time.Now().Add(s.Config.Session.SessionTimeout),
 		Propagate:       propagate,

--- a/dfs/internal/datanode/types.go
+++ b/dfs/internal/datanode/types.go
@@ -34,7 +34,7 @@ type DataNodeClient struct {
 }
 
 type IReplicationManager interface {
-	paralellReplicate(nodes []*common.DataNodeInfo, chunkInfo common.ChunkHeader, data []byte, requiredReplicas int) error
+	paralellReplicate(nodes []*common.DataNodeInfo, chunkInfo common.ChunkHeader, data []byte, requiredReplicas int) ([]*common.DataNodeInfo, error)
 	replicate(ctx context.Context, client *DataNodeClient, req common.ChunkHeader, data []byte, clientLogger *slog.Logger) error
 }
 

--- a/dfs/internal/datanode/types.go
+++ b/dfs/internal/datanode/types.go
@@ -34,8 +34,8 @@ type DataNodeClient struct {
 }
 
 type IReplicationManager interface {
-	paralellReplicate(nodes []*common.DataNodeInfo, chunkInfo common.ChunkInfo, data []byte, requiredReplicas int) error
-	replicate(ctx context.Context, client *DataNodeClient, req common.ChunkInfo, data []byte, clientLogger *slog.Logger) error
+	paralellReplicate(nodes []*common.DataNodeInfo, chunkInfo common.ChunkHeader, data []byte, requiredReplicas int) error
+	replicate(ctx context.Context, client *DataNodeClient, req common.ChunkHeader, data []byte, clientLogger *slog.Logger) error
 }
 
 type ISessionManager interface {

--- a/dfs/internal/datanode/types.go
+++ b/dfs/internal/datanode/types.go
@@ -34,8 +34,8 @@ type DataNodeClient struct {
 }
 
 type IReplicationManager interface {
-	paralellReplicate(nodes []*common.DataNodeInfo, chunkMeta common.ChunkMeta, data []byte, requiredReplicas int) error
-	replicate(ctx context.Context, client *DataNodeClient, req common.ChunkMeta, data []byte, clientLogger *slog.Logger) error
+	paralellReplicate(nodes []*common.DataNodeInfo, chunkInfo common.ChunkInfo, data []byte, requiredReplicas int) error
+	replicate(ctx context.Context, client *DataNodeClient, req common.ChunkInfo, data []byte, clientLogger *slog.Logger) error
 }
 
 type ISessionManager interface {

--- a/dfs/internal/datanode/types.go
+++ b/dfs/internal/datanode/types.go
@@ -43,6 +43,7 @@ type ISessionManager interface {
 	Load(sessionID string) (*StreamingSession, bool)
 	Delete(sessionID string)
 	ExistsForChunk(chunkID string) bool
+	LoadByChunk(chunkID string) (*StreamingSession, bool)
 }
 
 func NewDataNodeServer(store storage.ChunkStorage, replicationManager IReplicationManager, sessionManager ISessionManager,

--- a/dfs/internal/datanode/types.go
+++ b/dfs/internal/datanode/types.go
@@ -12,19 +12,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-const (
-	DEFAULT_REPLICAS = 3
-)
-
-type SessionStatus int
-
-const (
-	SessionActive SessionStatus = iota
-	SessionCompleted
-	SessionFailed
-	SessionExpired
-)
-
 // Implements the proto.DataNodeServiceServer interface
 type DataNodeServer struct {
 	proto.UnimplementedDataNodeServiceServer

--- a/dfs/internal/storage/chunk.go
+++ b/dfs/internal/storage/chunk.go
@@ -6,7 +6,8 @@ type ChunkStorage interface {
 	Store(chunkHeader common.ChunkHeader, data []byte) error
 
 	GetChunkHeader(chunkID string) (common.ChunkHeader, error)
-	GetChunk(chunkID string) ([]byte, error)
+	GetChunkData(chunkID string) ([]byte, error)
+	GetChunk(chunkID string) (common.ChunkHeader, []byte, error)
 
 	Delete(chunkID string) error
 	Exists(chunkID string) bool

--- a/dfs/internal/storage/chunk.go
+++ b/dfs/internal/storage/chunk.go
@@ -1,8 +1,13 @@
 package storage
 
+import "github.com/mochivi/distributed-file-system/internal/common"
+
 type ChunkStorage interface {
-	Store(chunkID string, data []byte) error
-	Retrieve(chunkID string) ([]byte, error)
+	Store(chunkHeader common.ChunkHeader, data []byte) error
+
+	GetChunkHeader(chunkID string) (common.ChunkHeader, error)
+	GetChunk(chunkID string) ([]byte, error)
+
 	Delete(chunkID string) error
 	Exists(chunkID string) bool
 	List() ([]string, error)

--- a/dfs/internal/storage/encoding/serializer.go
+++ b/dfs/internal/storage/encoding/serializer.go
@@ -28,6 +28,7 @@ type Chunk struct {
 type ChunkSerializer interface {
 	SerializeHeader(chunkHeader common.ChunkHeader) ([]byte, error)
 	DeserializeHeader(file *os.File) (common.ChunkHeader, error)
+	HeaderSize() int
 }
 
 type ProtoSerializer struct {
@@ -98,4 +99,8 @@ func (s *ProtoSerializer) DeserializeHeader(file *os.File) (common.ChunkHeader, 
 		return common.ChunkHeader{}, err
 	}
 	return common.ChunkHeaderFromProto(headerPB), nil
+}
+
+func (s *ProtoSerializer) HeaderSize() int {
+	return 13 // 4 B magic + 1 B version + 4 B length + 4 B header
 }

--- a/dfs/internal/storage/encoding/serializer.go
+++ b/dfs/internal/storage/encoding/serializer.go
@@ -1,0 +1,101 @@
+package encoding
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"os"
+
+	"github.com/mochivi/distributed-file-system/internal/common"
+	"github.com/mochivi/distributed-file-system/pkg/proto"
+	pb "google.golang.org/protobuf/proto"
+)
+
+type ChunkHeader struct {
+	Magic    string
+	Version  byte
+	ID       string
+	Index    int
+	Size     int
+	Checksum string
+}
+
+type Chunk struct {
+	Header ChunkHeader
+	Data   []byte
+}
+
+type ChunkSerializer interface {
+	SerializeHeader(chunkHeader common.ChunkHeader) ([]byte, error)
+	DeserializeHeader(file *os.File) (common.ChunkHeader, error)
+}
+
+type ProtoSerializer struct {
+	Magic   string
+	Version byte
+}
+
+func NewProtoSerializer() ChunkSerializer {
+	return &ProtoSerializer{
+		Magic:   "PSCH",
+		Version: 1,
+	}
+}
+
+func (s *ProtoSerializer) SerializeHeader(chunkHeader common.ChunkHeader) ([]byte, error) {
+	// 1) marshal header
+	headerPB := chunkHeader.ToProto()
+	headerBytes, err := pb.Marshal(headerPB)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2) build file: magic + ver + len + header + data
+	buf := new(bytes.Buffer)
+	buf.WriteString(s.Magic) // 4 B magic
+	buf.WriteByte(s.Version) // 1 B version
+
+	binary.Write(buf, binary.BigEndian, uint32(len(headerBytes))) // 4 B length
+	buf.Write(headerBytes)
+
+	return buf.Bytes(), nil
+}
+
+func (s *ProtoSerializer) DeserializeHeader(file *os.File) (common.ChunkHeader, error) {
+	// 1) read magic
+	magic := make([]byte, 4)
+	if _, err := file.Read(magic); err != nil {
+		return common.ChunkHeader{}, err
+	}
+	if string(magic) != s.Magic {
+		return common.ChunkHeader{}, fmt.Errorf("invalid magic: %s", string(magic))
+	}
+
+	// 2) read version
+	version := make([]byte, 1)
+	if _, err := file.Read(version); err != nil {
+		return common.ChunkHeader{}, err
+	}
+	if version[0] != s.Version {
+		return common.ChunkHeader{}, fmt.Errorf("invalid version: %d", version[0])
+	}
+
+	// 3) read length
+	length := make([]byte, 4)
+	if _, err := file.Read(length); err != nil {
+		return common.ChunkHeader{}, err
+	}
+	lengthInt := binary.BigEndian.Uint32(length)
+
+	// 4) read header
+	headerBytes := make([]byte, lengthInt)
+	if _, err := file.Read(headerBytes); err != nil {
+		return common.ChunkHeader{}, err
+	}
+
+	headerPB := &proto.ChunkHeader{}
+	if err := pb.Unmarshal(headerBytes, headerPB); err != nil {
+		return common.ChunkHeader{}, err
+	}
+	return common.ChunkHeaderFromProto(headerPB), nil
+}

--- a/dfs/pkg/proto/common.pb.go
+++ b/dfs/pkg/proto/common.pb.go
@@ -156,19 +156,93 @@ func (x *FileInfo) GetChecksum() string {
 	return ""
 }
 
-type ChunkInfo struct {
+type ChunkHeader struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Size          int64                  `protobuf:"varint,2,opt,name=size,proto3" json:"size,omitempty"`
+	Version       uint32                 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
+	Index         int32                  `protobuf:"varint,3,opt,name=index,proto3" json:"index,omitempty"`
+	Size          int64                  `protobuf:"varint,4,opt,name=size,proto3" json:"size,omitempty"`
+	Checksum      string                 `protobuf:"bytes,5,opt,name=checksum,proto3" json:"checksum,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ChunkHeader) Reset() {
+	*x = ChunkHeader{}
+	mi := &file_common_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ChunkHeader) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ChunkHeader) ProtoMessage() {}
+
+func (x *ChunkHeader) ProtoReflect() protoreflect.Message {
+	mi := &file_common_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ChunkHeader.ProtoReflect.Descriptor instead.
+func (*ChunkHeader) Descriptor() ([]byte, []int) {
+	return file_common_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *ChunkHeader) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *ChunkHeader) GetVersion() uint32 {
+	if x != nil {
+		return x.Version
+	}
+	return 0
+}
+
+func (x *ChunkHeader) GetIndex() int32 {
+	if x != nil {
+		return x.Index
+	}
+	return 0
+}
+
+func (x *ChunkHeader) GetSize() int64 {
+	if x != nil {
+		return x.Size
+	}
+	return 0
+}
+
+func (x *ChunkHeader) GetChecksum() string {
+	if x != nil {
+		return x.Checksum
+	}
+	return ""
+}
+
+type ChunkInfo struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Header        *ChunkHeader           `protobuf:"bytes,1,opt,name=header,proto3" json:"header,omitempty"`
 	Replicas      []*DataNodeInfo        `protobuf:"bytes,3,rep,name=replicas,proto3" json:"replicas,omitempty"` // DataNodes storing this chunk
-	Checksum      string                 `protobuf:"bytes,4,opt,name=checksum,proto3" json:"checksum,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ChunkInfo) Reset() {
 	*x = ChunkInfo{}
-	mi := &file_common_proto_msgTypes[1]
+	mi := &file_common_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -180,7 +254,7 @@ func (x *ChunkInfo) String() string {
 func (*ChunkInfo) ProtoMessage() {}
 
 func (x *ChunkInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[1]
+	mi := &file_common_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -193,21 +267,14 @@ func (x *ChunkInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChunkInfo.ProtoReflect.Descriptor instead.
 func (*ChunkInfo) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{1}
+	return file_common_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *ChunkInfo) GetId() string {
+func (x *ChunkInfo) GetHeader() *ChunkHeader {
 	if x != nil {
-		return x.Id
+		return x.Header
 	}
-	return ""
-}
-
-func (x *ChunkInfo) GetSize() int64 {
-	if x != nil {
-		return x.Size
-	}
-	return 0
+	return nil
 }
 
 func (x *ChunkInfo) GetReplicas() []*DataNodeInfo {
@@ -215,13 +282,6 @@ func (x *ChunkInfo) GetReplicas() []*DataNodeInfo {
 		return x.Replicas
 	}
 	return nil
-}
-
-func (x *ChunkInfo) GetChecksum() string {
-	if x != nil {
-		return x.Checksum
-	}
-	return ""
 }
 
 type DataNodeInfo struct {
@@ -239,7 +299,7 @@ type DataNodeInfo struct {
 
 func (x *DataNodeInfo) Reset() {
 	*x = DataNodeInfo{}
-	mi := &file_common_proto_msgTypes[2]
+	mi := &file_common_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -251,7 +311,7 @@ func (x *DataNodeInfo) String() string {
 func (*DataNodeInfo) ProtoMessage() {}
 
 func (x *DataNodeInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[2]
+	mi := &file_common_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -264,7 +324,7 @@ func (x *DataNodeInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DataNodeInfo.ProtoReflect.Descriptor instead.
 func (*DataNodeInfo) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{2}
+	return file_common_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *DataNodeInfo) GetId() string {
@@ -326,7 +386,7 @@ type HealthStatus struct {
 
 func (x *HealthStatus) Reset() {
 	*x = HealthStatus{}
-	mi := &file_common_proto_msgTypes[3]
+	mi := &file_common_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -338,7 +398,7 @@ func (x *HealthStatus) String() string {
 func (*HealthStatus) ProtoMessage() {}
 
 func (x *HealthStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_common_proto_msgTypes[3]
+	mi := &file_common_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -351,7 +411,7 @@ func (x *HealthStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthStatus.ProtoReflect.Descriptor instead.
 func (*HealthStatus) Descriptor() ([]byte, []int) {
-	return file_common_proto_rawDescGZIP(), []int{3}
+	return file_common_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *HealthStatus) GetStatus() NodeStatus {
@@ -381,12 +441,16 @@ const file_common_proto_rawDesc = "" +
 	"\x06chunks\x18\x04 \x03(\v2\x0e.dfs.ChunkInfoR\x06chunks\x129\n" +
 	"\n" +
 	"created_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12\x1a\n" +
-	"\bchecksum\x18\x06 \x01(\tR\bchecksum\"z\n" +
-	"\tChunkInfo\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
-	"\x04size\x18\x02 \x01(\x03R\x04size\x12-\n" +
-	"\breplicas\x18\x03 \x03(\v2\x11.dfs.DataNodeInfoR\breplicas\x12\x1a\n" +
-	"\bchecksum\x18\x04 \x01(\tR\bchecksum\"\xe3\x01\n" +
+	"\bchecksum\x18\x06 \x01(\tR\bchecksum\"}\n" +
+	"\vChunkHeader\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
+	"\aversion\x18\x02 \x01(\rR\aversion\x12\x14\n" +
+	"\x05index\x18\x03 \x01(\x05R\x05index\x12\x12\n" +
+	"\x04size\x18\x04 \x01(\x03R\x04size\x12\x1a\n" +
+	"\bchecksum\x18\x05 \x01(\tR\bchecksum\"d\n" +
+	"\tChunkInfo\x12(\n" +
+	"\x06header\x18\x01 \x01(\v2\x10.dfs.ChunkHeaderR\x06header\x12-\n" +
+	"\breplicas\x18\x03 \x03(\v2\x11.dfs.DataNodeInfoR\breplicas\"\xe3\x01\n" +
 	"\fDataNodeInfo\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1d\n" +
 	"\n" +
@@ -418,28 +482,30 @@ func file_common_proto_rawDescGZIP() []byte {
 }
 
 var file_common_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_common_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_common_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_common_proto_goTypes = []any{
 	(NodeStatus)(0),               // 0: dfs.NodeStatus
 	(*FileInfo)(nil),              // 1: dfs.FileInfo
-	(*ChunkInfo)(nil),             // 2: dfs.ChunkInfo
-	(*DataNodeInfo)(nil),          // 3: dfs.DataNodeInfo
-	(*HealthStatus)(nil),          // 4: dfs.HealthStatus
-	(*timestamppb.Timestamp)(nil), // 5: google.protobuf.Timestamp
+	(*ChunkHeader)(nil),           // 2: dfs.ChunkHeader
+	(*ChunkInfo)(nil),             // 3: dfs.ChunkInfo
+	(*DataNodeInfo)(nil),          // 4: dfs.DataNodeInfo
+	(*HealthStatus)(nil),          // 5: dfs.HealthStatus
+	(*timestamppb.Timestamp)(nil), // 6: google.protobuf.Timestamp
 }
 var file_common_proto_depIdxs = []int32{
-	2, // 0: dfs.FileInfo.chunks:type_name -> dfs.ChunkInfo
-	5, // 1: dfs.FileInfo.created_at:type_name -> google.protobuf.Timestamp
-	3, // 2: dfs.ChunkInfo.replicas:type_name -> dfs.DataNodeInfo
-	0, // 3: dfs.DataNodeInfo.status:type_name -> dfs.NodeStatus
-	5, // 4: dfs.DataNodeInfo.last_seen:type_name -> google.protobuf.Timestamp
-	0, // 5: dfs.HealthStatus.status:type_name -> dfs.NodeStatus
-	5, // 6: dfs.HealthStatus.last_seen:type_name -> google.protobuf.Timestamp
-	7, // [7:7] is the sub-list for method output_type
-	7, // [7:7] is the sub-list for method input_type
-	7, // [7:7] is the sub-list for extension type_name
-	7, // [7:7] is the sub-list for extension extendee
-	0, // [0:7] is the sub-list for field type_name
+	3, // 0: dfs.FileInfo.chunks:type_name -> dfs.ChunkInfo
+	6, // 1: dfs.FileInfo.created_at:type_name -> google.protobuf.Timestamp
+	2, // 2: dfs.ChunkInfo.header:type_name -> dfs.ChunkHeader
+	4, // 3: dfs.ChunkInfo.replicas:type_name -> dfs.DataNodeInfo
+	0, // 4: dfs.DataNodeInfo.status:type_name -> dfs.NodeStatus
+	6, // 5: dfs.DataNodeInfo.last_seen:type_name -> google.protobuf.Timestamp
+	0, // 6: dfs.HealthStatus.status:type_name -> dfs.NodeStatus
+	6, // 7: dfs.HealthStatus.last_seen:type_name -> google.protobuf.Timestamp
+	8, // [8:8] is the sub-list for method output_type
+	8, // [8:8] is the sub-list for method input_type
+	8, // [8:8] is the sub-list for extension type_name
+	8, // [8:8] is the sub-list for extension extendee
+	0, // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_common_proto_init() }
@@ -453,7 +519,7 @@ func file_common_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_common_proto_rawDesc), len(file_common_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/dfs/pkg/proto/common.proto
+++ b/dfs/pkg/proto/common.proto
@@ -16,12 +16,18 @@ message FileInfo {
   string checksum = 6;
 }
 
-message ChunkInfo {
+message ChunkHeader {
   string id = 1;
-  int64 size = 2;
-  repeated DataNodeInfo replicas = 3;  // DataNodes storing this chunk
-  string checksum = 4;
+  uint32 version = 2;
+  int32 index = 3;
+  int64 size = 4;
+  string checksum = 5;
 }
+
+message ChunkInfo {
+  ChunkHeader header = 1;
+  repeated DataNodeInfo replicas = 3;  // DataNodes storing this chunk
+}  
 
 message DataNodeInfo {
   string id = 1;

--- a/dfs/pkg/proto/coordinator.pb.go
+++ b/dfs/pkg/proto/coordinator.pb.go
@@ -195,7 +195,7 @@ func (x *UploadResponse) GetSessionId() string {
 type ChunkLocation struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ChunkId       string                 `protobuf:"bytes,1,opt,name=chunk_id,json=chunkId,proto3" json:"chunk_id,omitempty"`
-	Node          *DataNodeInfo          `protobuf:"bytes,2,opt,name=node,proto3" json:"node,omitempty"`
+	Nodes         []*DataNodeInfo        `protobuf:"bytes,2,rep,name=nodes,proto3" json:"nodes,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -237,9 +237,9 @@ func (x *ChunkLocation) GetChunkId() string {
 	return ""
 }
 
-func (x *ChunkLocation) GetNode() *DataNodeInfo {
+func (x *ChunkLocation) GetNodes() []*DataNodeInfo {
 	if x != nil {
-		return x.Node
+		return x.Nodes
 	}
 	return nil
 }
@@ -1075,10 +1075,10 @@ const file_coordinator_proto_rawDesc = "" +
 	"\x0eUploadResponse\x12;\n" +
 	"\x0fchunk_locations\x18\x01 \x03(\v2\x12.dfs.ChunkLocationR\x0echunkLocations\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x02 \x01(\tR\tsessionId\"Q\n" +
+	"session_id\x18\x02 \x01(\tR\tsessionId\"S\n" +
 	"\rChunkLocation\x12\x19\n" +
-	"\bchunk_id\x18\x01 \x01(\tR\achunkId\x12%\n" +
-	"\x04node\x18\x02 \x01(\v2\x11.dfs.DataNodeInfoR\x04node\"%\n" +
+	"\bchunk_id\x18\x01 \x01(\tR\achunkId\x12'\n" +
+	"\x05nodes\x18\x02 \x03(\v2\x11.dfs.DataNodeInfoR\x05nodes\"%\n" +
 	"\x0fDownloadRequest\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\"\x9a\x01\n" +
 	"\x10DownloadResponse\x12*\n" +
@@ -1192,7 +1192,7 @@ var file_coordinator_proto_goTypes = []any{
 }
 var file_coordinator_proto_depIdxs = []int32{
 	3,  // 0: dfs.UploadResponse.chunk_locations:type_name -> dfs.ChunkLocation
-	19, // 1: dfs.ChunkLocation.node:type_name -> dfs.DataNodeInfo
+	19, // 1: dfs.ChunkLocation.nodes:type_name -> dfs.DataNodeInfo
 	20, // 2: dfs.DownloadResponse.file_info:type_name -> dfs.FileInfo
 	3,  // 3: dfs.DownloadResponse.chunk_locations:type_name -> dfs.ChunkLocation
 	21, // 4: dfs.ConfirmUploadRequest.chunk_infos:type_name -> dfs.ChunkInfo

--- a/dfs/pkg/proto/coordinator.pb.go
+++ b/dfs/pkg/proto/coordinator.pb.go
@@ -293,6 +293,7 @@ type DownloadResponse struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	FileInfo       *FileInfo              `protobuf:"bytes,1,opt,name=file_info,json=fileInfo,proto3" json:"file_info,omitempty"`
 	ChunkLocations []*ChunkLocation       `protobuf:"bytes,2,rep,name=chunk_locations,json=chunkLocations,proto3" json:"chunk_locations,omitempty"`
+	SessionId      string                 `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -339,6 +340,13 @@ func (x *DownloadResponse) GetChunkLocations() []*ChunkLocation {
 		return x.ChunkLocations
 	}
 	return nil
+}
+
+func (x *DownloadResponse) GetSessionId() string {
+	if x != nil {
+		return x.SessionId
+	}
+	return ""
 }
 
 // Delete file request/response
@@ -1072,10 +1080,12 @@ const file_coordinator_proto_rawDesc = "" +
 	"\bchunk_id\x18\x01 \x01(\tR\achunkId\x12%\n" +
 	"\x04node\x18\x02 \x01(\v2\x11.dfs.DataNodeInfoR\x04node\"%\n" +
 	"\x0fDownloadRequest\x12\x12\n" +
-	"\x04path\x18\x01 \x01(\tR\x04path\"{\n" +
+	"\x04path\x18\x01 \x01(\tR\x04path\"\x9a\x01\n" +
 	"\x10DownloadResponse\x12*\n" +
 	"\tfile_info\x18\x01 \x01(\v2\r.dfs.FileInfoR\bfileInfo\x12;\n" +
-	"\x0fchunk_locations\x18\x02 \x03(\v2\x12.dfs.ChunkLocationR\x0echunkLocations\"#\n" +
+	"\x0fchunk_locations\x18\x02 \x03(\v2\x12.dfs.ChunkLocationR\x0echunkLocations\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x03 \x01(\tR\tsessionId\"#\n" +
 	"\rDeleteRequest\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\"D\n" +
 	"\x0eDeleteResponse\x12\x18\n" +

--- a/dfs/pkg/proto/coordinator.proto
+++ b/dfs/pkg/proto/coordinator.proto
@@ -47,6 +47,7 @@ message DownloadRequest {
 message DownloadResponse {
   FileInfo file_info = 1;
   repeated ChunkLocation chunk_locations = 2;
+  string session_id = 3;
 }
 
 // Delete file request/response

--- a/dfs/pkg/proto/coordinator.proto
+++ b/dfs/pkg/proto/coordinator.proto
@@ -37,7 +37,7 @@ message UploadResponse {
 
 message ChunkLocation {
   string chunk_id = 1;
-  DataNodeInfo node = 2;
+  repeated DataNodeInfo nodes = 2;
 }
 
 // Download file request/response

--- a/dfs/pkg/proto/datanode.pb.go
+++ b/dfs/pkg/proto/datanode.pb.go
@@ -22,8 +22,8 @@ const (
 )
 
 type UploadChunkRequest struct {
-	state     protoimpl.MessageState `protogen:"open.v1"`
-	ChunkInfo *ChunkInfo             `protobuf:"bytes,1,opt,name=chunk_info,json=chunkInfo,proto3" json:"chunk_info,omitempty"`
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	ChunkHeader *ChunkHeader           `protobuf:"bytes,1,opt,name=chunk_header,json=chunkHeader,proto3" json:"chunk_header,omitempty"`
 	// true  => receiver must replicate further (uploader is a client -> primary)
 	// false => receiver just stores the chunk (uploader is another DataNode)
 	Propagate     bool `protobuf:"varint,2,opt,name=propagate,proto3" json:"propagate,omitempty"`
@@ -61,9 +61,9 @@ func (*UploadChunkRequest) Descriptor() ([]byte, []int) {
 	return file_datanode_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *UploadChunkRequest) GetChunkInfo() *ChunkInfo {
+func (x *UploadChunkRequest) GetChunkHeader() *ChunkHeader {
 	if x != nil {
-		return x.ChunkInfo
+		return x.ChunkHeader
 	}
 	return nil
 }
@@ -135,6 +135,58 @@ func (x *NodeReady) GetSessionId() string {
 	return ""
 }
 
+type DownloadReady struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Ready         *NodeReady             `protobuf:"bytes,1,opt,name=ready,proto3" json:"ready,omitempty"`
+	ChunkHeader   *ChunkHeader           `protobuf:"bytes,2,opt,name=chunk_header,json=chunkHeader,proto3" json:"chunk_header,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DownloadReady) Reset() {
+	*x = DownloadReady{}
+	mi := &file_datanode_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DownloadReady) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DownloadReady) ProtoMessage() {}
+
+func (x *DownloadReady) ProtoReflect() protoreflect.Message {
+	mi := &file_datanode_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DownloadReady.ProtoReflect.Descriptor instead.
+func (*DownloadReady) Descriptor() ([]byte, []int) {
+	return file_datanode_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *DownloadReady) GetReady() *NodeReady {
+	if x != nil {
+		return x.Ready
+	}
+	return nil
+}
+
+func (x *DownloadReady) GetChunkHeader() *ChunkHeader {
+	if x != nil {
+		return x.ChunkHeader
+	}
+	return nil
+}
+
 // PrepareChunkDownload request/response
 type DownloadChunkRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -145,7 +197,7 @@ type DownloadChunkRequest struct {
 
 func (x *DownloadChunkRequest) Reset() {
 	*x = DownloadChunkRequest{}
-	mi := &file_datanode_proto_msgTypes[2]
+	mi := &file_datanode_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -157,7 +209,7 @@ func (x *DownloadChunkRequest) String() string {
 func (*DownloadChunkRequest) ProtoMessage() {}
 
 func (x *DownloadChunkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_datanode_proto_msgTypes[2]
+	mi := &file_datanode_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -170,7 +222,7 @@ func (x *DownloadChunkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadChunkRequest.ProtoReflect.Descriptor instead.
 func (*DownloadChunkRequest) Descriptor() ([]byte, []int) {
-	return file_datanode_proto_rawDescGZIP(), []int{2}
+	return file_datanode_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *DownloadChunkRequest) GetChunkId() string {
@@ -181,15 +233,16 @@ func (x *DownloadChunkRequest) GetChunkId() string {
 }
 
 type DownloadStreamRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	SessionId       string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	ChunkStreamSize int32                  `protobuf:"varint,2,opt,name=chunk_stream_size,json=chunkStreamSize,proto3" json:"chunk_stream_size,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *DownloadStreamRequest) Reset() {
 	*x = DownloadStreamRequest{}
-	mi := &file_datanode_proto_msgTypes[3]
+	mi := &file_datanode_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -201,7 +254,7 @@ func (x *DownloadStreamRequest) String() string {
 func (*DownloadStreamRequest) ProtoMessage() {}
 
 func (x *DownloadStreamRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_datanode_proto_msgTypes[3]
+	mi := &file_datanode_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -214,7 +267,7 @@ func (x *DownloadStreamRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DownloadStreamRequest.ProtoReflect.Descriptor instead.
 func (*DownloadStreamRequest) Descriptor() ([]byte, []int) {
-	return file_datanode_proto_rawDescGZIP(), []int{3}
+	return file_datanode_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *DownloadStreamRequest) GetSessionId() string {
@@ -222,6 +275,13 @@ func (x *DownloadStreamRequest) GetSessionId() string {
 		return x.SessionId
 	}
 	return ""
+}
+
+func (x *DownloadStreamRequest) GetChunkStreamSize() int32 {
+	if x != nil {
+		return x.ChunkStreamSize
+	}
+	return 0
 }
 
 // Delete chunk request/response
@@ -234,7 +294,7 @@ type DeleteChunkRequest struct {
 
 func (x *DeleteChunkRequest) Reset() {
 	*x = DeleteChunkRequest{}
-	mi := &file_datanode_proto_msgTypes[4]
+	mi := &file_datanode_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -246,7 +306,7 @@ func (x *DeleteChunkRequest) String() string {
 func (*DeleteChunkRequest) ProtoMessage() {}
 
 func (x *DeleteChunkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_datanode_proto_msgTypes[4]
+	mi := &file_datanode_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -259,7 +319,7 @@ func (x *DeleteChunkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteChunkRequest.ProtoReflect.Descriptor instead.
 func (*DeleteChunkRequest) Descriptor() ([]byte, []int) {
-	return file_datanode_proto_rawDescGZIP(), []int{4}
+	return file_datanode_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *DeleteChunkRequest) GetChunkId() string {
@@ -279,7 +339,7 @@ type DeleteChunkResponse struct {
 
 func (x *DeleteChunkResponse) Reset() {
 	*x = DeleteChunkResponse{}
-	mi := &file_datanode_proto_msgTypes[5]
+	mi := &file_datanode_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -291,7 +351,7 @@ func (x *DeleteChunkResponse) String() string {
 func (*DeleteChunkResponse) ProtoMessage() {}
 
 func (x *DeleteChunkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datanode_proto_msgTypes[5]
+	mi := &file_datanode_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -304,7 +364,7 @@ func (x *DeleteChunkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteChunkResponse.ProtoReflect.Descriptor instead.
 func (*DeleteChunkResponse) Descriptor() ([]byte, []int) {
-	return file_datanode_proto_rawDescGZIP(), []int{5}
+	return file_datanode_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *DeleteChunkResponse) GetSuccess() bool {
@@ -335,7 +395,7 @@ type ChunkDataStream struct {
 
 func (x *ChunkDataStream) Reset() {
 	*x = ChunkDataStream{}
-	mi := &file_datanode_proto_msgTypes[6]
+	mi := &file_datanode_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -347,7 +407,7 @@ func (x *ChunkDataStream) String() string {
 func (*ChunkDataStream) ProtoMessage() {}
 
 func (x *ChunkDataStream) ProtoReflect() protoreflect.Message {
-	mi := &file_datanode_proto_msgTypes[6]
+	mi := &file_datanode_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -360,7 +420,7 @@ func (x *ChunkDataStream) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChunkDataStream.ProtoReflect.Descriptor instead.
 func (*ChunkDataStream) Descriptor() ([]byte, []int) {
-	return file_datanode_proto_rawDescGZIP(), []int{6}
+	return file_datanode_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *ChunkDataStream) GetSessionId() string {
@@ -418,7 +478,7 @@ type ChunkDataAck struct {
 
 func (x *ChunkDataAck) Reset() {
 	*x = ChunkDataAck{}
-	mi := &file_datanode_proto_msgTypes[7]
+	mi := &file_datanode_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -430,7 +490,7 @@ func (x *ChunkDataAck) String() string {
 func (*ChunkDataAck) ProtoMessage() {}
 
 func (x *ChunkDataAck) ProtoReflect() protoreflect.Message {
-	mi := &file_datanode_proto_msgTypes[7]
+	mi := &file_datanode_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -443,7 +503,7 @@ func (x *ChunkDataAck) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChunkDataAck.ProtoReflect.Descriptor instead.
 func (*ChunkDataAck) Descriptor() ([]byte, []int) {
-	return file_datanode_proto_rawDescGZIP(), []int{7}
+	return file_datanode_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ChunkDataAck) GetSessionId() string {
@@ -490,7 +550,7 @@ type HealthCheckRequest struct {
 
 func (x *HealthCheckRequest) Reset() {
 	*x = HealthCheckRequest{}
-	mi := &file_datanode_proto_msgTypes[8]
+	mi := &file_datanode_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -502,7 +562,7 @@ func (x *HealthCheckRequest) String() string {
 func (*HealthCheckRequest) ProtoMessage() {}
 
 func (x *HealthCheckRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_datanode_proto_msgTypes[8]
+	mi := &file_datanode_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -515,7 +575,7 @@ func (x *HealthCheckRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthCheckRequest.ProtoReflect.Descriptor instead.
 func (*HealthCheckRequest) Descriptor() ([]byte, []int) {
-	return file_datanode_proto_rawDescGZIP(), []int{8}
+	return file_datanode_proto_rawDescGZIP(), []int{9}
 }
 
 type HealthCheckResponse struct {
@@ -527,7 +587,7 @@ type HealthCheckResponse struct {
 
 func (x *HealthCheckResponse) Reset() {
 	*x = HealthCheckResponse{}
-	mi := &file_datanode_proto_msgTypes[9]
+	mi := &file_datanode_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -539,7 +599,7 @@ func (x *HealthCheckResponse) String() string {
 func (*HealthCheckResponse) ProtoMessage() {}
 
 func (x *HealthCheckResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_datanode_proto_msgTypes[9]
+	mi := &file_datanode_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -552,7 +612,7 @@ func (x *HealthCheckResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthCheckResponse.ProtoReflect.Descriptor instead.
 func (*HealthCheckResponse) Descriptor() ([]byte, []int) {
-	return file_datanode_proto_rawDescGZIP(), []int{9}
+	return file_datanode_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *HealthCheckResponse) GetStatus() *HealthStatus {
@@ -566,21 +626,24 @@ var File_datanode_proto protoreflect.FileDescriptor
 
 const file_datanode_proto_rawDesc = "" +
 	"\n" +
-	"\x0edatanode.proto\x12\x03dfs\x1a\fcommon.proto\"a\n" +
-	"\x12UploadChunkRequest\x12-\n" +
-	"\n" +
-	"chunk_info\x18\x01 \x01(\v2\x0e.dfs.ChunkInfoR\tchunkInfo\x12\x1c\n" +
+	"\x0edatanode.proto\x12\x03dfs\x1a\fcommon.proto\"g\n" +
+	"\x12UploadChunkRequest\x123\n" +
+	"\fchunk_header\x18\x01 \x01(\v2\x10.dfs.ChunkHeaderR\vchunkHeader\x12\x1c\n" +
 	"\tpropagate\x18\x02 \x01(\bR\tpropagate\"\\\n" +
 	"\tNodeReady\x12\x16\n" +
 	"\x06accept\x18\x01 \x01(\bR\x06accept\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x03 \x01(\tR\tsessionId\"1\n" +
+	"session_id\x18\x03 \x01(\tR\tsessionId\"j\n" +
+	"\rDownloadReady\x12$\n" +
+	"\x05ready\x18\x01 \x01(\v2\x0e.dfs.NodeReadyR\x05ready\x123\n" +
+	"\fchunk_header\x18\x02 \x01(\v2\x10.dfs.ChunkHeaderR\vchunkHeader\"1\n" +
 	"\x14DownloadChunkRequest\x12\x19\n" +
-	"\bchunk_id\x18\x01 \x01(\tR\achunkId\"6\n" +
+	"\bchunk_id\x18\x01 \x01(\tR\achunkId\"b\n" +
 	"\x15DownloadStreamRequest\x12\x1d\n" +
 	"\n" +
-	"session_id\x18\x01 \x01(\tR\tsessionId\"/\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\x12*\n" +
+	"\x11chunk_stream_size\x18\x02 \x01(\x05R\x0fchunkStreamSize\"/\n" +
 	"\x12DeleteChunkRequest\x12\x19\n" +
 	"\bchunk_id\x18\x01 \x01(\tR\achunkId\"I\n" +
 	"\x13DeleteChunkResponse\x12\x18\n" +
@@ -603,10 +666,10 @@ const file_datanode_proto_rawDesc = "" +
 	"\x0eready_for_next\x18\x05 \x01(\bR\freadyForNext\"\x14\n" +
 	"\x12HealthCheckRequest\"@\n" +
 	"\x13HealthCheckResponse\x12)\n" +
-	"\x06status\x18\x01 \x01(\v2\x11.dfs.HealthStatusR\x06status2\xa4\x03\n" +
+	"\x06status\x18\x01 \x01(\v2\x11.dfs.HealthStatusR\x06status2\xa8\x03\n" +
 	"\x0fDataNodeService\x12=\n" +
-	"\x12PrepareChunkUpload\x12\x17.dfs.UploadChunkRequest\x1a\x0e.dfs.NodeReady\x12A\n" +
-	"\x14PrepareChunkDownload\x12\x19.dfs.DownloadChunkRequest\x1a\x0e.dfs.NodeReady\x12@\n" +
+	"\x12PrepareChunkUpload\x12\x17.dfs.UploadChunkRequest\x1a\x0e.dfs.NodeReady\x12E\n" +
+	"\x14PrepareChunkDownload\x12\x19.dfs.DownloadChunkRequest\x1a\x12.dfs.DownloadReady\x12@\n" +
 	"\x11UploadChunkStream\x12\x14.dfs.ChunkDataStream\x1a\x11.dfs.ChunkDataAck(\x010\x01\x12I\n" +
 	"\x13DownloadChunkStream\x12\x1a.dfs.DownloadStreamRequest\x1a\x14.dfs.ChunkDataStream0\x01\x12@\n" +
 	"\vDeleteChunk\x12\x17.dfs.DeleteChunkRequest\x1a\x18.dfs.DeleteChunkResponse\x12@\n" +
@@ -624,41 +687,44 @@ func file_datanode_proto_rawDescGZIP() []byte {
 	return file_datanode_proto_rawDescData
 }
 
-var file_datanode_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_datanode_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_datanode_proto_goTypes = []any{
 	(*UploadChunkRequest)(nil),    // 0: dfs.UploadChunkRequest
 	(*NodeReady)(nil),             // 1: dfs.NodeReady
-	(*DownloadChunkRequest)(nil),  // 2: dfs.DownloadChunkRequest
-	(*DownloadStreamRequest)(nil), // 3: dfs.DownloadStreamRequest
-	(*DeleteChunkRequest)(nil),    // 4: dfs.DeleteChunkRequest
-	(*DeleteChunkResponse)(nil),   // 5: dfs.DeleteChunkResponse
-	(*ChunkDataStream)(nil),       // 6: dfs.ChunkDataStream
-	(*ChunkDataAck)(nil),          // 7: dfs.ChunkDataAck
-	(*HealthCheckRequest)(nil),    // 8: dfs.HealthCheckRequest
-	(*HealthCheckResponse)(nil),   // 9: dfs.HealthCheckResponse
-	(*ChunkInfo)(nil),             // 10: dfs.ChunkInfo
-	(*HealthStatus)(nil),          // 11: dfs.HealthStatus
+	(*DownloadReady)(nil),         // 2: dfs.DownloadReady
+	(*DownloadChunkRequest)(nil),  // 3: dfs.DownloadChunkRequest
+	(*DownloadStreamRequest)(nil), // 4: dfs.DownloadStreamRequest
+	(*DeleteChunkRequest)(nil),    // 5: dfs.DeleteChunkRequest
+	(*DeleteChunkResponse)(nil),   // 6: dfs.DeleteChunkResponse
+	(*ChunkDataStream)(nil),       // 7: dfs.ChunkDataStream
+	(*ChunkDataAck)(nil),          // 8: dfs.ChunkDataAck
+	(*HealthCheckRequest)(nil),    // 9: dfs.HealthCheckRequest
+	(*HealthCheckResponse)(nil),   // 10: dfs.HealthCheckResponse
+	(*ChunkHeader)(nil),           // 11: dfs.ChunkHeader
+	(*HealthStatus)(nil),          // 12: dfs.HealthStatus
 }
 var file_datanode_proto_depIdxs = []int32{
-	10, // 0: dfs.UploadChunkRequest.chunk_info:type_name -> dfs.ChunkInfo
-	11, // 1: dfs.HealthCheckResponse.status:type_name -> dfs.HealthStatus
-	0,  // 2: dfs.DataNodeService.PrepareChunkUpload:input_type -> dfs.UploadChunkRequest
-	2,  // 3: dfs.DataNodeService.PrepareChunkDownload:input_type -> dfs.DownloadChunkRequest
-	6,  // 4: dfs.DataNodeService.UploadChunkStream:input_type -> dfs.ChunkDataStream
-	3,  // 5: dfs.DataNodeService.DownloadChunkStream:input_type -> dfs.DownloadStreamRequest
-	4,  // 6: dfs.DataNodeService.DeleteChunk:input_type -> dfs.DeleteChunkRequest
-	8,  // 7: dfs.DataNodeService.HealthCheck:input_type -> dfs.HealthCheckRequest
-	1,  // 8: dfs.DataNodeService.PrepareChunkUpload:output_type -> dfs.NodeReady
-	1,  // 9: dfs.DataNodeService.PrepareChunkDownload:output_type -> dfs.NodeReady
-	7,  // 10: dfs.DataNodeService.UploadChunkStream:output_type -> dfs.ChunkDataAck
-	6,  // 11: dfs.DataNodeService.DownloadChunkStream:output_type -> dfs.ChunkDataStream
-	5,  // 12: dfs.DataNodeService.DeleteChunk:output_type -> dfs.DeleteChunkResponse
-	9,  // 13: dfs.DataNodeService.HealthCheck:output_type -> dfs.HealthCheckResponse
-	8,  // [8:14] is the sub-list for method output_type
-	2,  // [2:8] is the sub-list for method input_type
-	2,  // [2:2] is the sub-list for extension type_name
-	2,  // [2:2] is the sub-list for extension extendee
-	0,  // [0:2] is the sub-list for field type_name
+	11, // 0: dfs.UploadChunkRequest.chunk_header:type_name -> dfs.ChunkHeader
+	1,  // 1: dfs.DownloadReady.ready:type_name -> dfs.NodeReady
+	11, // 2: dfs.DownloadReady.chunk_header:type_name -> dfs.ChunkHeader
+	12, // 3: dfs.HealthCheckResponse.status:type_name -> dfs.HealthStatus
+	0,  // 4: dfs.DataNodeService.PrepareChunkUpload:input_type -> dfs.UploadChunkRequest
+	3,  // 5: dfs.DataNodeService.PrepareChunkDownload:input_type -> dfs.DownloadChunkRequest
+	7,  // 6: dfs.DataNodeService.UploadChunkStream:input_type -> dfs.ChunkDataStream
+	4,  // 7: dfs.DataNodeService.DownloadChunkStream:input_type -> dfs.DownloadStreamRequest
+	5,  // 8: dfs.DataNodeService.DeleteChunk:input_type -> dfs.DeleteChunkRequest
+	9,  // 9: dfs.DataNodeService.HealthCheck:input_type -> dfs.HealthCheckRequest
+	1,  // 10: dfs.DataNodeService.PrepareChunkUpload:output_type -> dfs.NodeReady
+	2,  // 11: dfs.DataNodeService.PrepareChunkDownload:output_type -> dfs.DownloadReady
+	8,  // 12: dfs.DataNodeService.UploadChunkStream:output_type -> dfs.ChunkDataAck
+	7,  // 13: dfs.DataNodeService.DownloadChunkStream:output_type -> dfs.ChunkDataStream
+	6,  // 14: dfs.DataNodeService.DeleteChunk:output_type -> dfs.DeleteChunkResponse
+	10, // 15: dfs.DataNodeService.HealthCheck:output_type -> dfs.HealthCheckResponse
+	10, // [10:16] is the sub-list for method output_type
+	4,  // [4:10] is the sub-list for method input_type
+	4,  // [4:4] is the sub-list for extension type_name
+	4,  // [4:4] is the sub-list for extension extendee
+	0,  // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_datanode_proto_init() }
@@ -673,7 +739,7 @@ func file_datanode_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_datanode_proto_rawDesc), len(file_datanode_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/dfs/pkg/proto/datanode.pb.go
+++ b/dfs/pkg/proto/datanode.pb.go
@@ -21,33 +21,30 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Hand-shake from uploader peer (client or other DataNode)
-type ChunkMeta struct {
+type UploadChunkRequest struct {
 	state     protoimpl.MessageState `protogen:"open.v1"`
-	ChunkId   string                 `protobuf:"bytes,1,opt,name=chunk_id,json=chunkId,proto3" json:"chunk_id,omitempty"`
-	ChunkSize int64                  `protobuf:"varint,2,opt,name=chunk_size,json=chunkSize,proto3" json:"chunk_size,omitempty"`
-	Checksum  string                 `protobuf:"bytes,3,opt,name=checksum,proto3" json:"checksum,omitempty"`
+	ChunkInfo *ChunkInfo             `protobuf:"bytes,1,opt,name=chunk_info,json=chunkInfo,proto3" json:"chunk_info,omitempty"`
 	// true  => receiver must replicate further (uploader is a client -> primary)
 	// false => receiver just stores the chunk (uploader is another DataNode)
-	Propagate     bool `protobuf:"varint,4,opt,name=propagate,proto3" json:"propagate,omitempty"`
+	Propagate     bool `protobuf:"varint,2,opt,name=propagate,proto3" json:"propagate,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ChunkMeta) Reset() {
-	*x = ChunkMeta{}
+func (x *UploadChunkRequest) Reset() {
+	*x = UploadChunkRequest{}
 	mi := &file_datanode_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ChunkMeta) String() string {
+func (x *UploadChunkRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ChunkMeta) ProtoMessage() {}
+func (*UploadChunkRequest) ProtoMessage() {}
 
-func (x *ChunkMeta) ProtoReflect() protoreflect.Message {
+func (x *UploadChunkRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_datanode_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -59,33 +56,19 @@ func (x *ChunkMeta) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ChunkMeta.ProtoReflect.Descriptor instead.
-func (*ChunkMeta) Descriptor() ([]byte, []int) {
+// Deprecated: Use UploadChunkRequest.ProtoReflect.Descriptor instead.
+func (*UploadChunkRequest) Descriptor() ([]byte, []int) {
 	return file_datanode_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *ChunkMeta) GetChunkId() string {
+func (x *UploadChunkRequest) GetChunkInfo() *ChunkInfo {
 	if x != nil {
-		return x.ChunkId
+		return x.ChunkInfo
 	}
-	return ""
+	return nil
 }
 
-func (x *ChunkMeta) GetChunkSize() int64 {
-	if x != nil {
-		return x.ChunkSize
-	}
-	return 0
-}
-
-func (x *ChunkMeta) GetChecksum() string {
-	if x != nil {
-		return x.Checksum
-	}
-	return ""
-}
-
-func (x *ChunkMeta) GetPropagate() bool {
+func (x *UploadChunkRequest) GetPropagate() bool {
 	if x != nil {
 		return x.Propagate
 	}
@@ -583,13 +566,11 @@ var File_datanode_proto protoreflect.FileDescriptor
 
 const file_datanode_proto_rawDesc = "" +
 	"\n" +
-	"\x0edatanode.proto\x12\x03dfs\x1a\fcommon.proto\"\x7f\n" +
-	"\tChunkMeta\x12\x19\n" +
-	"\bchunk_id\x18\x01 \x01(\tR\achunkId\x12\x1d\n" +
+	"\x0edatanode.proto\x12\x03dfs\x1a\fcommon.proto\"a\n" +
+	"\x12UploadChunkRequest\x12-\n" +
 	"\n" +
-	"chunk_size\x18\x02 \x01(\x03R\tchunkSize\x12\x1a\n" +
-	"\bchecksum\x18\x03 \x01(\tR\bchecksum\x12\x1c\n" +
-	"\tpropagate\x18\x04 \x01(\bR\tpropagate\"\\\n" +
+	"chunk_info\x18\x01 \x01(\v2\x0e.dfs.ChunkInfoR\tchunkInfo\x12\x1c\n" +
+	"\tpropagate\x18\x02 \x01(\bR\tpropagate\"\\\n" +
 	"\tNodeReady\x12\x16\n" +
 	"\x06accept\x18\x01 \x01(\bR\x06accept\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12\x1d\n" +
@@ -622,9 +603,9 @@ const file_datanode_proto_rawDesc = "" +
 	"\x0eready_for_next\x18\x05 \x01(\bR\freadyForNext\"\x14\n" +
 	"\x12HealthCheckRequest\"@\n" +
 	"\x13HealthCheckResponse\x12)\n" +
-	"\x06status\x18\x01 \x01(\v2\x11.dfs.HealthStatusR\x06status2\x9b\x03\n" +
-	"\x0fDataNodeService\x124\n" +
-	"\x12PrepareChunkUpload\x12\x0e.dfs.ChunkMeta\x1a\x0e.dfs.NodeReady\x12A\n" +
+	"\x06status\x18\x01 \x01(\v2\x11.dfs.HealthStatusR\x06status2\xa4\x03\n" +
+	"\x0fDataNodeService\x12=\n" +
+	"\x12PrepareChunkUpload\x12\x17.dfs.UploadChunkRequest\x1a\x0e.dfs.NodeReady\x12A\n" +
 	"\x14PrepareChunkDownload\x12\x19.dfs.DownloadChunkRequest\x1a\x0e.dfs.NodeReady\x12@\n" +
 	"\x11UploadChunkStream\x12\x14.dfs.ChunkDataStream\x1a\x11.dfs.ChunkDataAck(\x010\x01\x12I\n" +
 	"\x13DownloadChunkStream\x12\x1a.dfs.DownloadStreamRequest\x1a\x14.dfs.ChunkDataStream0\x01\x12@\n" +
@@ -645,7 +626,7 @@ func file_datanode_proto_rawDescGZIP() []byte {
 
 var file_datanode_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_datanode_proto_goTypes = []any{
-	(*ChunkMeta)(nil),             // 0: dfs.ChunkMeta
+	(*UploadChunkRequest)(nil),    // 0: dfs.UploadChunkRequest
 	(*NodeReady)(nil),             // 1: dfs.NodeReady
 	(*DownloadChunkRequest)(nil),  // 2: dfs.DownloadChunkRequest
 	(*DownloadStreamRequest)(nil), // 3: dfs.DownloadStreamRequest
@@ -655,27 +636,29 @@ var file_datanode_proto_goTypes = []any{
 	(*ChunkDataAck)(nil),          // 7: dfs.ChunkDataAck
 	(*HealthCheckRequest)(nil),    // 8: dfs.HealthCheckRequest
 	(*HealthCheckResponse)(nil),   // 9: dfs.HealthCheckResponse
-	(*HealthStatus)(nil),          // 10: dfs.HealthStatus
+	(*ChunkInfo)(nil),             // 10: dfs.ChunkInfo
+	(*HealthStatus)(nil),          // 11: dfs.HealthStatus
 }
 var file_datanode_proto_depIdxs = []int32{
-	10, // 0: dfs.HealthCheckResponse.status:type_name -> dfs.HealthStatus
-	0,  // 1: dfs.DataNodeService.PrepareChunkUpload:input_type -> dfs.ChunkMeta
-	2,  // 2: dfs.DataNodeService.PrepareChunkDownload:input_type -> dfs.DownloadChunkRequest
-	6,  // 3: dfs.DataNodeService.UploadChunkStream:input_type -> dfs.ChunkDataStream
-	3,  // 4: dfs.DataNodeService.DownloadChunkStream:input_type -> dfs.DownloadStreamRequest
-	4,  // 5: dfs.DataNodeService.DeleteChunk:input_type -> dfs.DeleteChunkRequest
-	8,  // 6: dfs.DataNodeService.HealthCheck:input_type -> dfs.HealthCheckRequest
-	1,  // 7: dfs.DataNodeService.PrepareChunkUpload:output_type -> dfs.NodeReady
-	1,  // 8: dfs.DataNodeService.PrepareChunkDownload:output_type -> dfs.NodeReady
-	7,  // 9: dfs.DataNodeService.UploadChunkStream:output_type -> dfs.ChunkDataAck
-	6,  // 10: dfs.DataNodeService.DownloadChunkStream:output_type -> dfs.ChunkDataStream
-	5,  // 11: dfs.DataNodeService.DeleteChunk:output_type -> dfs.DeleteChunkResponse
-	9,  // 12: dfs.DataNodeService.HealthCheck:output_type -> dfs.HealthCheckResponse
-	7,  // [7:13] is the sub-list for method output_type
-	1,  // [1:7] is the sub-list for method input_type
-	1,  // [1:1] is the sub-list for extension type_name
-	1,  // [1:1] is the sub-list for extension extendee
-	0,  // [0:1] is the sub-list for field type_name
+	10, // 0: dfs.UploadChunkRequest.chunk_info:type_name -> dfs.ChunkInfo
+	11, // 1: dfs.HealthCheckResponse.status:type_name -> dfs.HealthStatus
+	0,  // 2: dfs.DataNodeService.PrepareChunkUpload:input_type -> dfs.UploadChunkRequest
+	2,  // 3: dfs.DataNodeService.PrepareChunkDownload:input_type -> dfs.DownloadChunkRequest
+	6,  // 4: dfs.DataNodeService.UploadChunkStream:input_type -> dfs.ChunkDataStream
+	3,  // 5: dfs.DataNodeService.DownloadChunkStream:input_type -> dfs.DownloadStreamRequest
+	4,  // 6: dfs.DataNodeService.DeleteChunk:input_type -> dfs.DeleteChunkRequest
+	8,  // 7: dfs.DataNodeService.HealthCheck:input_type -> dfs.HealthCheckRequest
+	1,  // 8: dfs.DataNodeService.PrepareChunkUpload:output_type -> dfs.NodeReady
+	1,  // 9: dfs.DataNodeService.PrepareChunkDownload:output_type -> dfs.NodeReady
+	7,  // 10: dfs.DataNodeService.UploadChunkStream:output_type -> dfs.ChunkDataAck
+	6,  // 11: dfs.DataNodeService.DownloadChunkStream:output_type -> dfs.ChunkDataStream
+	5,  // 12: dfs.DataNodeService.DeleteChunk:output_type -> dfs.DeleteChunkResponse
+	9,  // 13: dfs.DataNodeService.HealthCheck:output_type -> dfs.HealthCheckResponse
+	8,  // [8:14] is the sub-list for method output_type
+	2,  // [2:8] is the sub-list for method input_type
+	2,  // [2:2] is the sub-list for extension type_name
+	2,  // [2:2] is the sub-list for extension extendee
+	0,  // [0:2] is the sub-list for field type_name
 }
 
 func init() { file_datanode_proto_init() }

--- a/dfs/pkg/proto/datanode.pb.go
+++ b/dfs/pkg/proto/datanode.pb.go
@@ -472,6 +472,7 @@ type ChunkDataAck struct {
 	Message       string                 `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
 	BytesReceived int64                  `protobuf:"varint,4,opt,name=bytes_received,json=bytesReceived,proto3" json:"bytes_received,omitempty"` // Total bytes received so far
 	ReadyForNext  bool                   `protobuf:"varint,5,opt,name=ready_for_next,json=readyForNext,proto3" json:"ready_for_next,omitempty"`  // Flow control: ready for next chunk
+	Replicas      []*DataNodeInfo        `protobuf:"bytes,6,rep,name=replicas,proto3" json:"replicas,omitempty"`                                 // The last request send out by the server confirms all replica nodes
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -539,6 +540,13 @@ func (x *ChunkDataAck) GetReadyForNext() bool {
 		return x.ReadyForNext
 	}
 	return false
+}
+
+func (x *ChunkDataAck) GetReplicas() []*DataNodeInfo {
+	if x != nil {
+		return x.Replicas
+	}
+	return nil
 }
 
 // Health check request/response
@@ -656,14 +664,15 @@ const file_datanode_proto_rawDesc = "" +
 	"\x04data\x18\x03 \x01(\fR\x04data\x12\x16\n" +
 	"\x06offset\x18\x04 \x01(\x03R\x06offset\x12\x19\n" +
 	"\bis_final\x18\x05 \x01(\bR\aisFinal\x12)\n" +
-	"\x10partial_checksum\x18\x06 \x01(\tR\x0fpartialChecksum\"\xae\x01\n" +
+	"\x10partial_checksum\x18\x06 \x01(\tR\x0fpartialChecksum\"\xdd\x01\n" +
 	"\fChunkDataAck\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x18\n" +
 	"\asuccess\x18\x02 \x01(\bR\asuccess\x12\x18\n" +
 	"\amessage\x18\x03 \x01(\tR\amessage\x12%\n" +
 	"\x0ebytes_received\x18\x04 \x01(\x03R\rbytesReceived\x12$\n" +
-	"\x0eready_for_next\x18\x05 \x01(\bR\freadyForNext\"\x14\n" +
+	"\x0eready_for_next\x18\x05 \x01(\bR\freadyForNext\x12-\n" +
+	"\breplicas\x18\x06 \x03(\v2\x11.dfs.DataNodeInfoR\breplicas\"\x14\n" +
 	"\x12HealthCheckRequest\"@\n" +
 	"\x13HealthCheckResponse\x12)\n" +
 	"\x06status\x18\x01 \x01(\v2\x11.dfs.HealthStatusR\x06status2\xa8\x03\n" +
@@ -701,30 +710,32 @@ var file_datanode_proto_goTypes = []any{
 	(*HealthCheckRequest)(nil),    // 9: dfs.HealthCheckRequest
 	(*HealthCheckResponse)(nil),   // 10: dfs.HealthCheckResponse
 	(*ChunkHeader)(nil),           // 11: dfs.ChunkHeader
-	(*HealthStatus)(nil),          // 12: dfs.HealthStatus
+	(*DataNodeInfo)(nil),          // 12: dfs.DataNodeInfo
+	(*HealthStatus)(nil),          // 13: dfs.HealthStatus
 }
 var file_datanode_proto_depIdxs = []int32{
 	11, // 0: dfs.UploadChunkRequest.chunk_header:type_name -> dfs.ChunkHeader
 	1,  // 1: dfs.DownloadReady.ready:type_name -> dfs.NodeReady
 	11, // 2: dfs.DownloadReady.chunk_header:type_name -> dfs.ChunkHeader
-	12, // 3: dfs.HealthCheckResponse.status:type_name -> dfs.HealthStatus
-	0,  // 4: dfs.DataNodeService.PrepareChunkUpload:input_type -> dfs.UploadChunkRequest
-	3,  // 5: dfs.DataNodeService.PrepareChunkDownload:input_type -> dfs.DownloadChunkRequest
-	7,  // 6: dfs.DataNodeService.UploadChunkStream:input_type -> dfs.ChunkDataStream
-	4,  // 7: dfs.DataNodeService.DownloadChunkStream:input_type -> dfs.DownloadStreamRequest
-	5,  // 8: dfs.DataNodeService.DeleteChunk:input_type -> dfs.DeleteChunkRequest
-	9,  // 9: dfs.DataNodeService.HealthCheck:input_type -> dfs.HealthCheckRequest
-	1,  // 10: dfs.DataNodeService.PrepareChunkUpload:output_type -> dfs.NodeReady
-	2,  // 11: dfs.DataNodeService.PrepareChunkDownload:output_type -> dfs.DownloadReady
-	8,  // 12: dfs.DataNodeService.UploadChunkStream:output_type -> dfs.ChunkDataAck
-	7,  // 13: dfs.DataNodeService.DownloadChunkStream:output_type -> dfs.ChunkDataStream
-	6,  // 14: dfs.DataNodeService.DeleteChunk:output_type -> dfs.DeleteChunkResponse
-	10, // 15: dfs.DataNodeService.HealthCheck:output_type -> dfs.HealthCheckResponse
-	10, // [10:16] is the sub-list for method output_type
-	4,  // [4:10] is the sub-list for method input_type
-	4,  // [4:4] is the sub-list for extension type_name
-	4,  // [4:4] is the sub-list for extension extendee
-	0,  // [0:4] is the sub-list for field type_name
+	12, // 3: dfs.ChunkDataAck.replicas:type_name -> dfs.DataNodeInfo
+	13, // 4: dfs.HealthCheckResponse.status:type_name -> dfs.HealthStatus
+	0,  // 5: dfs.DataNodeService.PrepareChunkUpload:input_type -> dfs.UploadChunkRequest
+	3,  // 6: dfs.DataNodeService.PrepareChunkDownload:input_type -> dfs.DownloadChunkRequest
+	7,  // 7: dfs.DataNodeService.UploadChunkStream:input_type -> dfs.ChunkDataStream
+	4,  // 8: dfs.DataNodeService.DownloadChunkStream:input_type -> dfs.DownloadStreamRequest
+	5,  // 9: dfs.DataNodeService.DeleteChunk:input_type -> dfs.DeleteChunkRequest
+	9,  // 10: dfs.DataNodeService.HealthCheck:input_type -> dfs.HealthCheckRequest
+	1,  // 11: dfs.DataNodeService.PrepareChunkUpload:output_type -> dfs.NodeReady
+	2,  // 12: dfs.DataNodeService.PrepareChunkDownload:output_type -> dfs.DownloadReady
+	8,  // 13: dfs.DataNodeService.UploadChunkStream:output_type -> dfs.ChunkDataAck
+	7,  // 14: dfs.DataNodeService.DownloadChunkStream:output_type -> dfs.ChunkDataStream
+	6,  // 15: dfs.DataNodeService.DeleteChunk:output_type -> dfs.DeleteChunkResponse
+	10, // 16: dfs.DataNodeService.HealthCheck:output_type -> dfs.HealthCheckResponse
+	11, // [11:17] is the sub-list for method output_type
+	5,  // [5:11] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_datanode_proto_init() }

--- a/dfs/pkg/proto/datanode.pb.go
+++ b/dfs/pkg/proto/datanode.pb.go
@@ -21,7 +21,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Hand-shake from uploader (client or other DataNode)
+// Hand-shake from uploader peer (client or other DataNode)
 type ChunkMeta struct {
 	state     protoimpl.MessageState `protogen:"open.v1"`
 	ChunkId   string                 `protobuf:"bytes,1,opt,name=chunk_id,json=chunkId,proto3" json:"chunk_id,omitempty"`
@@ -92,7 +92,7 @@ func (x *ChunkMeta) GetPropagate() bool {
 	return false
 }
 
-type ChunkUploadReady struct {
+type NodeReady struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Accept        bool                   `protobuf:"varint,1,opt,name=accept,proto3" json:"accept,omitempty"`
 	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
@@ -101,20 +101,20 @@ type ChunkUploadReady struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *ChunkUploadReady) Reset() {
-	*x = ChunkUploadReady{}
+func (x *NodeReady) Reset() {
+	*x = NodeReady{}
 	mi := &file_datanode_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *ChunkUploadReady) String() string {
+func (x *NodeReady) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*ChunkUploadReady) ProtoMessage() {}
+func (*NodeReady) ProtoMessage() {}
 
-func (x *ChunkUploadReady) ProtoReflect() protoreflect.Message {
+func (x *NodeReady) ProtoReflect() protoreflect.Message {
 	mi := &file_datanode_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -126,54 +126,54 @@ func (x *ChunkUploadReady) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use ChunkUploadReady.ProtoReflect.Descriptor instead.
-func (*ChunkUploadReady) Descriptor() ([]byte, []int) {
+// Deprecated: Use NodeReady.ProtoReflect.Descriptor instead.
+func (*NodeReady) Descriptor() ([]byte, []int) {
 	return file_datanode_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *ChunkUploadReady) GetAccept() bool {
+func (x *NodeReady) GetAccept() bool {
 	if x != nil {
 		return x.Accept
 	}
 	return false
 }
 
-func (x *ChunkUploadReady) GetMessage() string {
+func (x *NodeReady) GetMessage() string {
 	if x != nil {
 		return x.Message
 	}
 	return ""
 }
 
-func (x *ChunkUploadReady) GetSessionId() string {
+func (x *NodeReady) GetSessionId() string {
 	if x != nil {
 		return x.SessionId
 	}
 	return ""
 }
 
-// Retrieve chunk request/response
-type RetrieveChunkRequest struct {
+// PrepareChunkDownload request/response
+type DownloadChunkRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ChunkId       string                 `protobuf:"bytes,1,opt,name=chunk_id,json=chunkId,proto3" json:"chunk_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *RetrieveChunkRequest) Reset() {
-	*x = RetrieveChunkRequest{}
+func (x *DownloadChunkRequest) Reset() {
+	*x = DownloadChunkRequest{}
 	mi := &file_datanode_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *RetrieveChunkRequest) String() string {
+func (x *DownloadChunkRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*RetrieveChunkRequest) ProtoMessage() {}
+func (*DownloadChunkRequest) ProtoMessage() {}
 
-func (x *RetrieveChunkRequest) ProtoReflect() protoreflect.Message {
+func (x *DownloadChunkRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_datanode_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -185,40 +185,39 @@ func (x *RetrieveChunkRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use RetrieveChunkRequest.ProtoReflect.Descriptor instead.
-func (*RetrieveChunkRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use DownloadChunkRequest.ProtoReflect.Descriptor instead.
+func (*DownloadChunkRequest) Descriptor() ([]byte, []int) {
 	return file_datanode_proto_rawDescGZIP(), []int{2}
 }
 
-func (x *RetrieveChunkRequest) GetChunkId() string {
+func (x *DownloadChunkRequest) GetChunkId() string {
 	if x != nil {
 		return x.ChunkId
 	}
 	return ""
 }
 
-type RetrieveChunkResponse struct {
+type DownloadStreamRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Data          []byte                 `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
-	Checksum      string                 `protobuf:"bytes,2,opt,name=checksum,proto3" json:"checksum,omitempty"`
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *RetrieveChunkResponse) Reset() {
-	*x = RetrieveChunkResponse{}
+func (x *DownloadStreamRequest) Reset() {
+	*x = DownloadStreamRequest{}
 	mi := &file_datanode_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *RetrieveChunkResponse) String() string {
+func (x *DownloadStreamRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*RetrieveChunkResponse) ProtoMessage() {}
+func (*DownloadStreamRequest) ProtoMessage() {}
 
-func (x *RetrieveChunkResponse) ProtoReflect() protoreflect.Message {
+func (x *DownloadStreamRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_datanode_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -230,21 +229,14 @@ func (x *RetrieveChunkResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use RetrieveChunkResponse.ProtoReflect.Descriptor instead.
-func (*RetrieveChunkResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use DownloadStreamRequest.ProtoReflect.Descriptor instead.
+func (*DownloadStreamRequest) Descriptor() ([]byte, []int) {
 	return file_datanode_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *RetrieveChunkResponse) GetData() []byte {
+func (x *DownloadStreamRequest) GetSessionId() string {
 	if x != nil {
-		return x.Data
-	}
-	return nil
-}
-
-func (x *RetrieveChunkResponse) GetChecksum() string {
-	if x != nil {
-		return x.Checksum
+		return x.SessionId
 	}
 	return ""
 }
@@ -597,17 +589,17 @@ const file_datanode_proto_rawDesc = "" +
 	"\n" +
 	"chunk_size\x18\x02 \x01(\x03R\tchunkSize\x12\x1a\n" +
 	"\bchecksum\x18\x03 \x01(\tR\bchecksum\x12\x1c\n" +
-	"\tpropagate\x18\x04 \x01(\bR\tpropagate\"c\n" +
-	"\x10ChunkUploadReady\x12\x16\n" +
+	"\tpropagate\x18\x04 \x01(\bR\tpropagate\"\\\n" +
+	"\tNodeReady\x12\x16\n" +
 	"\x06accept\x18\x01 \x01(\bR\x06accept\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x03 \x01(\tR\tsessionId\"1\n" +
-	"\x14RetrieveChunkRequest\x12\x19\n" +
-	"\bchunk_id\x18\x01 \x01(\tR\achunkId\"G\n" +
-	"\x15RetrieveChunkResponse\x12\x12\n" +
-	"\x04data\x18\x01 \x01(\fR\x04data\x12\x1a\n" +
-	"\bchecksum\x18\x02 \x01(\tR\bchecksum\"/\n" +
+	"\x14DownloadChunkRequest\x12\x19\n" +
+	"\bchunk_id\x18\x01 \x01(\tR\achunkId\"6\n" +
+	"\x15DownloadStreamRequest\x12\x1d\n" +
+	"\n" +
+	"session_id\x18\x01 \x01(\tR\tsessionId\"/\n" +
 	"\x12DeleteChunkRequest\x12\x19\n" +
 	"\bchunk_id\x18\x01 \x01(\tR\achunkId\"I\n" +
 	"\x13DeleteChunkResponse\x12\x18\n" +
@@ -630,12 +622,13 @@ const file_datanode_proto_rawDesc = "" +
 	"\x0eready_for_next\x18\x05 \x01(\bR\freadyForNext\"\x14\n" +
 	"\x12HealthCheckRequest\"@\n" +
 	"\x13HealthCheckResponse\x12)\n" +
-	"\x06status\x18\x01 \x01(\v2\x11.dfs.HealthStatusR\x06status2\xd6\x02\n" +
-	"\x0fDataNodeService\x12;\n" +
-	"\x12PrepareChunkUpload\x12\x0e.dfs.ChunkMeta\x1a\x15.dfs.ChunkUploadReady\x12F\n" +
-	"\rRetrieveChunk\x12\x19.dfs.RetrieveChunkRequest\x1a\x1a.dfs.RetrieveChunkResponse\x12@\n" +
-	"\vDeleteChunk\x12\x17.dfs.DeleteChunkRequest\x1a\x18.dfs.DeleteChunkResponse\x12:\n" +
-	"\vStreamChunk\x12\x14.dfs.ChunkDataStream\x1a\x11.dfs.ChunkDataAck(\x010\x01\x12@\n" +
+	"\x06status\x18\x01 \x01(\v2\x11.dfs.HealthStatusR\x06status2\x9b\x03\n" +
+	"\x0fDataNodeService\x124\n" +
+	"\x12PrepareChunkUpload\x12\x0e.dfs.ChunkMeta\x1a\x0e.dfs.NodeReady\x12A\n" +
+	"\x14PrepareChunkDownload\x12\x19.dfs.DownloadChunkRequest\x1a\x0e.dfs.NodeReady\x12@\n" +
+	"\x11UploadChunkStream\x12\x14.dfs.ChunkDataStream\x1a\x11.dfs.ChunkDataAck(\x010\x01\x12I\n" +
+	"\x13DownloadChunkStream\x12\x1a.dfs.DownloadStreamRequest\x1a\x14.dfs.ChunkDataStream0\x01\x12@\n" +
+	"\vDeleteChunk\x12\x17.dfs.DeleteChunkRequest\x1a\x18.dfs.DeleteChunkResponse\x12@\n" +
 	"\vHealthCheck\x12\x17.dfs.HealthCheckRequest\x1a\x18.dfs.HealthCheckResponseB\vZ\tpkg/protob\x06proto3"
 
 var (
@@ -653,9 +646,9 @@ func file_datanode_proto_rawDescGZIP() []byte {
 var file_datanode_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_datanode_proto_goTypes = []any{
 	(*ChunkMeta)(nil),             // 0: dfs.ChunkMeta
-	(*ChunkUploadReady)(nil),      // 1: dfs.ChunkUploadReady
-	(*RetrieveChunkRequest)(nil),  // 2: dfs.RetrieveChunkRequest
-	(*RetrieveChunkResponse)(nil), // 3: dfs.RetrieveChunkResponse
+	(*NodeReady)(nil),             // 1: dfs.NodeReady
+	(*DownloadChunkRequest)(nil),  // 2: dfs.DownloadChunkRequest
+	(*DownloadStreamRequest)(nil), // 3: dfs.DownloadStreamRequest
 	(*DeleteChunkRequest)(nil),    // 4: dfs.DeleteChunkRequest
 	(*DeleteChunkResponse)(nil),   // 5: dfs.DeleteChunkResponse
 	(*ChunkDataStream)(nil),       // 6: dfs.ChunkDataStream
@@ -667,17 +660,19 @@ var file_datanode_proto_goTypes = []any{
 var file_datanode_proto_depIdxs = []int32{
 	10, // 0: dfs.HealthCheckResponse.status:type_name -> dfs.HealthStatus
 	0,  // 1: dfs.DataNodeService.PrepareChunkUpload:input_type -> dfs.ChunkMeta
-	2,  // 2: dfs.DataNodeService.RetrieveChunk:input_type -> dfs.RetrieveChunkRequest
-	4,  // 3: dfs.DataNodeService.DeleteChunk:input_type -> dfs.DeleteChunkRequest
-	6,  // 4: dfs.DataNodeService.StreamChunk:input_type -> dfs.ChunkDataStream
-	8,  // 5: dfs.DataNodeService.HealthCheck:input_type -> dfs.HealthCheckRequest
-	1,  // 6: dfs.DataNodeService.PrepareChunkUpload:output_type -> dfs.ChunkUploadReady
-	3,  // 7: dfs.DataNodeService.RetrieveChunk:output_type -> dfs.RetrieveChunkResponse
-	5,  // 8: dfs.DataNodeService.DeleteChunk:output_type -> dfs.DeleteChunkResponse
-	7,  // 9: dfs.DataNodeService.StreamChunk:output_type -> dfs.ChunkDataAck
-	9,  // 10: dfs.DataNodeService.HealthCheck:output_type -> dfs.HealthCheckResponse
-	6,  // [6:11] is the sub-list for method output_type
-	1,  // [1:6] is the sub-list for method input_type
+	2,  // 2: dfs.DataNodeService.PrepareChunkDownload:input_type -> dfs.DownloadChunkRequest
+	6,  // 3: dfs.DataNodeService.UploadChunkStream:input_type -> dfs.ChunkDataStream
+	3,  // 4: dfs.DataNodeService.DownloadChunkStream:input_type -> dfs.DownloadStreamRequest
+	4,  // 5: dfs.DataNodeService.DeleteChunk:input_type -> dfs.DeleteChunkRequest
+	8,  // 6: dfs.DataNodeService.HealthCheck:input_type -> dfs.HealthCheckRequest
+	1,  // 7: dfs.DataNodeService.PrepareChunkUpload:output_type -> dfs.NodeReady
+	1,  // 8: dfs.DataNodeService.PrepareChunkDownload:output_type -> dfs.NodeReady
+	7,  // 9: dfs.DataNodeService.UploadChunkStream:output_type -> dfs.ChunkDataAck
+	6,  // 10: dfs.DataNodeService.DownloadChunkStream:output_type -> dfs.ChunkDataStream
+	5,  // 11: dfs.DataNodeService.DeleteChunk:output_type -> dfs.DeleteChunkResponse
+	9,  // 12: dfs.DataNodeService.HealthCheck:output_type -> dfs.HealthCheckResponse
+	7,  // [7:13] is the sub-list for method output_type
+	1,  // [1:7] is the sub-list for method input_type
 	1,  // [1:1] is the sub-list for extension type_name
 	1,  // [1:1] is the sub-list for extension extendee
 	0,  // [0:1] is the sub-list for field type_name

--- a/dfs/pkg/proto/datanode.proto
+++ b/dfs/pkg/proto/datanode.proto
@@ -78,6 +78,7 @@ message ChunkDataAck {
   string message = 3;
   int64 bytes_received = 4;       // Total bytes received so far
   bool ready_for_next = 5;        // Flow control: ready for next chunk
+  repeated DataNodeInfo replicas = 6; // The last request send out by the server confirms all replica nodes
 }
 
 // Health check request/response

--- a/dfs/pkg/proto/datanode.proto
+++ b/dfs/pkg/proto/datanode.proto
@@ -7,22 +7,27 @@ option go_package = "pkg/proto";
 import "common.proto";
 
 service DataNodeService {
-  // Hand-shake definitions from uploader (client or other DataNode)
-  // All operations follow a 2 step protocol -> first prepare -> stream data
-  rpc PrepareChunkUpload(ChunkMeta) returns (ChunkUploadReady);
+  // Hand-shake definitions from peer (upload and download, client or other DataNode) 
+  // Both operations follow a 2 step protocol: prepare -> stream data
+  rpc PrepareChunkUpload(ChunkMeta) returns (NodeReady);
+  rpc PrepareChunkDownload(DownloadChunkRequest) returns (NodeReady);
 
-  // Chunk operations
-  rpc RetrieveChunk(RetrieveChunkRequest) returns (RetrieveChunkResponse);
+  // Bidirectional stream for uploading chunk data to a node.
+  // The client streams data, the server streams back acknowledgements.
+  rpc UploadChunkStream(stream ChunkDataStream) returns (stream ChunkDataAck);
+  
+  // Server-side stream for downloading chunk data from a node.
+  // The client sends a single request, the server streams back data.
+  rpc DownloadChunkStream(DownloadStreamRequest) returns (stream ChunkDataStream);
+
+  // Unary operation to delete a chunk
   rpc DeleteChunk(DeleteChunkRequest) returns (DeleteChunkResponse);
 
-  // Receiving chunk data from stream
-  rpc StreamChunk(stream ChunkDataStream) returns (stream ChunkDataAck);
-  
   // Health check
   rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
 }
 
-// Hand-shake from uploader (client or other DataNode)
+// Hand-shake from uploader peer (client or other DataNode)
 message ChunkMeta {
   string chunk_id   = 1;
   int64  chunk_size = 2;
@@ -33,19 +38,18 @@ message ChunkMeta {
   bool    propagate = 4;
 }
 
-message ChunkUploadReady {
+message NodeReady {
   bool   accept     = 1;
   string message    = 2;
   string session_id = 3;
 }
 
-// Retrieve chunk request/response
-message RetrieveChunkRequest {
+// PrepareChunkDownload request/response
+message DownloadChunkRequest {
   string chunk_id = 1;
 }
-message RetrieveChunkResponse {
-  bytes data = 1;
-  string checksum = 2;
+message DownloadStreamRequest {
+  string session_id = 1;
 }
 
 // Delete chunk request/response
@@ -56,7 +60,6 @@ message DeleteChunkResponse {
   bool success = 1;
   string message = 2;
 }
-
 
 message ChunkDataStream {
   string session_id = 1;

--- a/dfs/pkg/proto/datanode.proto
+++ b/dfs/pkg/proto/datanode.proto
@@ -9,7 +9,7 @@ import "common.proto";
 service DataNodeService {
   // Hand-shake definitions from peer (upload and download, client or other DataNode) 
   // Both operations follow a 2 step protocol: prepare -> stream data
-  rpc PrepareChunkUpload(ChunkMeta) returns (NodeReady);
+  rpc PrepareChunkUpload(UploadChunkRequest) returns (NodeReady);
   rpc PrepareChunkDownload(DownloadChunkRequest) returns (NodeReady);
 
   // Bidirectional stream for uploading chunk data to a node.
@@ -27,15 +27,12 @@ service DataNodeService {
   rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
 }
 
-// Hand-shake from uploader peer (client or other DataNode)
-message ChunkMeta {
-  string chunk_id   = 1;
-  int64  chunk_size = 2;
-  string checksum   = 3;
-
+message UploadChunkRequest {
+  ChunkInfo chunk_info = 1;
+  
   // true  => receiver must replicate further (uploader is a client -> primary)
   // false => receiver just stores the chunk (uploader is another DataNode)
-  bool    propagate = 4;
+  bool propagate = 2;
 }
 
 message NodeReady {

--- a/dfs/pkg/proto/datanode.proto
+++ b/dfs/pkg/proto/datanode.proto
@@ -10,7 +10,7 @@ service DataNodeService {
   // Hand-shake definitions from peer (upload and download, client or other DataNode) 
   // Both operations follow a 2 step protocol: prepare -> stream data
   rpc PrepareChunkUpload(UploadChunkRequest) returns (NodeReady);
-  rpc PrepareChunkDownload(DownloadChunkRequest) returns (NodeReady);
+  rpc PrepareChunkDownload(DownloadChunkRequest) returns (DownloadReady);
 
   // Bidirectional stream for uploading chunk data to a node.
   // The client streams data, the server streams back acknowledgements.
@@ -28,7 +28,7 @@ service DataNodeService {
 }
 
 message UploadChunkRequest {
-  ChunkInfo chunk_info = 1;
+  ChunkHeader chunk_header = 1;
   
   // true  => receiver must replicate further (uploader is a client -> primary)
   // false => receiver just stores the chunk (uploader is another DataNode)
@@ -41,12 +41,18 @@ message NodeReady {
   string session_id = 3;
 }
 
+message DownloadReady {
+  NodeReady ready = 1;
+  ChunkHeader chunk_header = 2;
+}
+
 // PrepareChunkDownload request/response
 message DownloadChunkRequest {
   string chunk_id = 1;
 }
 message DownloadStreamRequest {
   string session_id = 1;
+  int32 chunk_stream_size = 2;
 }
 
 // Delete chunk request/response

--- a/dfs/pkg/proto/datanode_grpc.pb.go
+++ b/dfs/pkg/proto/datanode_grpc.pb.go
@@ -33,7 +33,7 @@ const (
 type DataNodeServiceClient interface {
 	// Hand-shake definitions from peer (upload and download, client or other DataNode)
 	// Both operations follow a 2 step protocol: prepare -> stream data
-	PrepareChunkUpload(ctx context.Context, in *ChunkMeta, opts ...grpc.CallOption) (*NodeReady, error)
+	PrepareChunkUpload(ctx context.Context, in *UploadChunkRequest, opts ...grpc.CallOption) (*NodeReady, error)
 	PrepareChunkDownload(ctx context.Context, in *DownloadChunkRequest, opts ...grpc.CallOption) (*NodeReady, error)
 	// Bidirectional stream for uploading chunk data to a node.
 	// The client streams data, the server streams back acknowledgements.
@@ -55,7 +55,7 @@ func NewDataNodeServiceClient(cc grpc.ClientConnInterface) DataNodeServiceClient
 	return &dataNodeServiceClient{cc}
 }
 
-func (c *dataNodeServiceClient) PrepareChunkUpload(ctx context.Context, in *ChunkMeta, opts ...grpc.CallOption) (*NodeReady, error) {
+func (c *dataNodeServiceClient) PrepareChunkUpload(ctx context.Context, in *UploadChunkRequest, opts ...grpc.CallOption) (*NodeReady, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(NodeReady)
 	err := c.cc.Invoke(ctx, DataNodeService_PrepareChunkUpload_FullMethodName, in, out, cOpts...)
@@ -133,7 +133,7 @@ func (c *dataNodeServiceClient) HealthCheck(ctx context.Context, in *HealthCheck
 type DataNodeServiceServer interface {
 	// Hand-shake definitions from peer (upload and download, client or other DataNode)
 	// Both operations follow a 2 step protocol: prepare -> stream data
-	PrepareChunkUpload(context.Context, *ChunkMeta) (*NodeReady, error)
+	PrepareChunkUpload(context.Context, *UploadChunkRequest) (*NodeReady, error)
 	PrepareChunkDownload(context.Context, *DownloadChunkRequest) (*NodeReady, error)
 	// Bidirectional stream for uploading chunk data to a node.
 	// The client streams data, the server streams back acknowledgements.
@@ -155,7 +155,7 @@ type DataNodeServiceServer interface {
 // pointer dereference when methods are called.
 type UnimplementedDataNodeServiceServer struct{}
 
-func (UnimplementedDataNodeServiceServer) PrepareChunkUpload(context.Context, *ChunkMeta) (*NodeReady, error) {
+func (UnimplementedDataNodeServiceServer) PrepareChunkUpload(context.Context, *UploadChunkRequest) (*NodeReady, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PrepareChunkUpload not implemented")
 }
 func (UnimplementedDataNodeServiceServer) PrepareChunkDownload(context.Context, *DownloadChunkRequest) (*NodeReady, error) {
@@ -195,7 +195,7 @@ func RegisterDataNodeServiceServer(s grpc.ServiceRegistrar, srv DataNodeServiceS
 }
 
 func _DataNodeService_PrepareChunkUpload_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ChunkMeta)
+	in := new(UploadChunkRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -207,7 +207,7 @@ func _DataNodeService_PrepareChunkUpload_Handler(srv interface{}, ctx context.Co
 		FullMethod: DataNodeService_PrepareChunkUpload_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataNodeServiceServer).PrepareChunkUpload(ctx, req.(*ChunkMeta))
+		return srv.(DataNodeServiceServer).PrepareChunkUpload(ctx, req.(*UploadChunkRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }

--- a/dfs/pkg/proto/datanode_grpc.pb.go
+++ b/dfs/pkg/proto/datanode_grpc.pb.go
@@ -19,25 +19,30 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	DataNodeService_PrepareChunkUpload_FullMethodName = "/dfs.DataNodeService/PrepareChunkUpload"
-	DataNodeService_RetrieveChunk_FullMethodName      = "/dfs.DataNodeService/RetrieveChunk"
-	DataNodeService_DeleteChunk_FullMethodName        = "/dfs.DataNodeService/DeleteChunk"
-	DataNodeService_StreamChunk_FullMethodName        = "/dfs.DataNodeService/StreamChunk"
-	DataNodeService_HealthCheck_FullMethodName        = "/dfs.DataNodeService/HealthCheck"
+	DataNodeService_PrepareChunkUpload_FullMethodName   = "/dfs.DataNodeService/PrepareChunkUpload"
+	DataNodeService_PrepareChunkDownload_FullMethodName = "/dfs.DataNodeService/PrepareChunkDownload"
+	DataNodeService_UploadChunkStream_FullMethodName    = "/dfs.DataNodeService/UploadChunkStream"
+	DataNodeService_DownloadChunkStream_FullMethodName  = "/dfs.DataNodeService/DownloadChunkStream"
+	DataNodeService_DeleteChunk_FullMethodName          = "/dfs.DataNodeService/DeleteChunk"
+	DataNodeService_HealthCheck_FullMethodName          = "/dfs.DataNodeService/HealthCheck"
 )
 
 // DataNodeServiceClient is the client API for DataNodeService service.
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 type DataNodeServiceClient interface {
-	// Hand-shake definitions from uploader (client or other DataNode)
-	// All operations follow a 2 step protocol -> first prepare -> stream data
-	PrepareChunkUpload(ctx context.Context, in *ChunkMeta, opts ...grpc.CallOption) (*ChunkUploadReady, error)
-	// Chunk operations
-	RetrieveChunk(ctx context.Context, in *RetrieveChunkRequest, opts ...grpc.CallOption) (*RetrieveChunkResponse, error)
+	// Hand-shake definitions from peer (upload and download, client or other DataNode)
+	// Both operations follow a 2 step protocol: prepare -> stream data
+	PrepareChunkUpload(ctx context.Context, in *ChunkMeta, opts ...grpc.CallOption) (*NodeReady, error)
+	PrepareChunkDownload(ctx context.Context, in *DownloadChunkRequest, opts ...grpc.CallOption) (*NodeReady, error)
+	// Bidirectional stream for uploading chunk data to a node.
+	// The client streams data, the server streams back acknowledgements.
+	UploadChunkStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[ChunkDataStream, ChunkDataAck], error)
+	// Server-side stream for downloading chunk data from a node.
+	// The client sends a single request, the server streams back data.
+	DownloadChunkStream(ctx context.Context, in *DownloadStreamRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ChunkDataStream], error)
+	// Unary operation to delete a chunk
 	DeleteChunk(ctx context.Context, in *DeleteChunkRequest, opts ...grpc.CallOption) (*DeleteChunkResponse, error)
-	// Receiving chunk data from stream
-	StreamChunk(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[ChunkDataStream, ChunkDataAck], error)
 	// Health check
 	HealthCheck(ctx context.Context, in *HealthCheckRequest, opts ...grpc.CallOption) (*HealthCheckResponse, error)
 }
@@ -50,9 +55,9 @@ func NewDataNodeServiceClient(cc grpc.ClientConnInterface) DataNodeServiceClient
 	return &dataNodeServiceClient{cc}
 }
 
-func (c *dataNodeServiceClient) PrepareChunkUpload(ctx context.Context, in *ChunkMeta, opts ...grpc.CallOption) (*ChunkUploadReady, error) {
+func (c *dataNodeServiceClient) PrepareChunkUpload(ctx context.Context, in *ChunkMeta, opts ...grpc.CallOption) (*NodeReady, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(ChunkUploadReady)
+	out := new(NodeReady)
 	err := c.cc.Invoke(ctx, DataNodeService_PrepareChunkUpload_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
@@ -60,15 +65,47 @@ func (c *dataNodeServiceClient) PrepareChunkUpload(ctx context.Context, in *Chun
 	return out, nil
 }
 
-func (c *dataNodeServiceClient) RetrieveChunk(ctx context.Context, in *RetrieveChunkRequest, opts ...grpc.CallOption) (*RetrieveChunkResponse, error) {
+func (c *dataNodeServiceClient) PrepareChunkDownload(ctx context.Context, in *DownloadChunkRequest, opts ...grpc.CallOption) (*NodeReady, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(RetrieveChunkResponse)
-	err := c.cc.Invoke(ctx, DataNodeService_RetrieveChunk_FullMethodName, in, out, cOpts...)
+	out := new(NodeReady)
+	err := c.cc.Invoke(ctx, DataNodeService_PrepareChunkDownload_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
+
+func (c *dataNodeServiceClient) UploadChunkStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[ChunkDataStream, ChunkDataAck], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &DataNodeService_ServiceDesc.Streams[0], DataNodeService_UploadChunkStream_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[ChunkDataStream, ChunkDataAck]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type DataNodeService_UploadChunkStreamClient = grpc.BidiStreamingClient[ChunkDataStream, ChunkDataAck]
+
+func (c *dataNodeServiceClient) DownloadChunkStream(ctx context.Context, in *DownloadStreamRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ChunkDataStream], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &DataNodeService_ServiceDesc.Streams[1], DataNodeService_DownloadChunkStream_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[DownloadStreamRequest, ChunkDataStream]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type DataNodeService_DownloadChunkStreamClient = grpc.ServerStreamingClient[ChunkDataStream]
 
 func (c *dataNodeServiceClient) DeleteChunk(ctx context.Context, in *DeleteChunkRequest, opts ...grpc.CallOption) (*DeleteChunkResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
@@ -79,19 +116,6 @@ func (c *dataNodeServiceClient) DeleteChunk(ctx context.Context, in *DeleteChunk
 	}
 	return out, nil
 }
-
-func (c *dataNodeServiceClient) StreamChunk(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[ChunkDataStream, ChunkDataAck], error) {
-	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	stream, err := c.cc.NewStream(ctx, &DataNodeService_ServiceDesc.Streams[0], DataNodeService_StreamChunk_FullMethodName, cOpts...)
-	if err != nil {
-		return nil, err
-	}
-	x := &grpc.GenericClientStream[ChunkDataStream, ChunkDataAck]{ClientStream: stream}
-	return x, nil
-}
-
-// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type DataNodeService_StreamChunkClient = grpc.BidiStreamingClient[ChunkDataStream, ChunkDataAck]
 
 func (c *dataNodeServiceClient) HealthCheck(ctx context.Context, in *HealthCheckRequest, opts ...grpc.CallOption) (*HealthCheckResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
@@ -107,14 +131,18 @@ func (c *dataNodeServiceClient) HealthCheck(ctx context.Context, in *HealthCheck
 // All implementations must embed UnimplementedDataNodeServiceServer
 // for forward compatibility.
 type DataNodeServiceServer interface {
-	// Hand-shake definitions from uploader (client or other DataNode)
-	// All operations follow a 2 step protocol -> first prepare -> stream data
-	PrepareChunkUpload(context.Context, *ChunkMeta) (*ChunkUploadReady, error)
-	// Chunk operations
-	RetrieveChunk(context.Context, *RetrieveChunkRequest) (*RetrieveChunkResponse, error)
+	// Hand-shake definitions from peer (upload and download, client or other DataNode)
+	// Both operations follow a 2 step protocol: prepare -> stream data
+	PrepareChunkUpload(context.Context, *ChunkMeta) (*NodeReady, error)
+	PrepareChunkDownload(context.Context, *DownloadChunkRequest) (*NodeReady, error)
+	// Bidirectional stream for uploading chunk data to a node.
+	// The client streams data, the server streams back acknowledgements.
+	UploadChunkStream(grpc.BidiStreamingServer[ChunkDataStream, ChunkDataAck]) error
+	// Server-side stream for downloading chunk data from a node.
+	// The client sends a single request, the server streams back data.
+	DownloadChunkStream(*DownloadStreamRequest, grpc.ServerStreamingServer[ChunkDataStream]) error
+	// Unary operation to delete a chunk
 	DeleteChunk(context.Context, *DeleteChunkRequest) (*DeleteChunkResponse, error)
-	// Receiving chunk data from stream
-	StreamChunk(grpc.BidiStreamingServer[ChunkDataStream, ChunkDataAck]) error
 	// Health check
 	HealthCheck(context.Context, *HealthCheckRequest) (*HealthCheckResponse, error)
 	mustEmbedUnimplementedDataNodeServiceServer()
@@ -127,17 +155,20 @@ type DataNodeServiceServer interface {
 // pointer dereference when methods are called.
 type UnimplementedDataNodeServiceServer struct{}
 
-func (UnimplementedDataNodeServiceServer) PrepareChunkUpload(context.Context, *ChunkMeta) (*ChunkUploadReady, error) {
+func (UnimplementedDataNodeServiceServer) PrepareChunkUpload(context.Context, *ChunkMeta) (*NodeReady, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PrepareChunkUpload not implemented")
 }
-func (UnimplementedDataNodeServiceServer) RetrieveChunk(context.Context, *RetrieveChunkRequest) (*RetrieveChunkResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method RetrieveChunk not implemented")
+func (UnimplementedDataNodeServiceServer) PrepareChunkDownload(context.Context, *DownloadChunkRequest) (*NodeReady, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method PrepareChunkDownload not implemented")
+}
+func (UnimplementedDataNodeServiceServer) UploadChunkStream(grpc.BidiStreamingServer[ChunkDataStream, ChunkDataAck]) error {
+	return status.Errorf(codes.Unimplemented, "method UploadChunkStream not implemented")
+}
+func (UnimplementedDataNodeServiceServer) DownloadChunkStream(*DownloadStreamRequest, grpc.ServerStreamingServer[ChunkDataStream]) error {
+	return status.Errorf(codes.Unimplemented, "method DownloadChunkStream not implemented")
 }
 func (UnimplementedDataNodeServiceServer) DeleteChunk(context.Context, *DeleteChunkRequest) (*DeleteChunkResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteChunk not implemented")
-}
-func (UnimplementedDataNodeServiceServer) StreamChunk(grpc.BidiStreamingServer[ChunkDataStream, ChunkDataAck]) error {
-	return status.Errorf(codes.Unimplemented, "method StreamChunk not implemented")
 }
 func (UnimplementedDataNodeServiceServer) HealthCheck(context.Context, *HealthCheckRequest) (*HealthCheckResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method HealthCheck not implemented")
@@ -181,23 +212,41 @@ func _DataNodeService_PrepareChunkUpload_Handler(srv interface{}, ctx context.Co
 	return interceptor(ctx, in, info, handler)
 }
 
-func _DataNodeService_RetrieveChunk_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(RetrieveChunkRequest)
+func _DataNodeService_PrepareChunkDownload_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DownloadChunkRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(DataNodeServiceServer).RetrieveChunk(ctx, in)
+		return srv.(DataNodeServiceServer).PrepareChunkDownload(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: DataNodeService_RetrieveChunk_FullMethodName,
+		FullMethod: DataNodeService_PrepareChunkDownload_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(DataNodeServiceServer).RetrieveChunk(ctx, req.(*RetrieveChunkRequest))
+		return srv.(DataNodeServiceServer).PrepareChunkDownload(ctx, req.(*DownloadChunkRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
+
+func _DataNodeService_UploadChunkStream_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(DataNodeServiceServer).UploadChunkStream(&grpc.GenericServerStream[ChunkDataStream, ChunkDataAck]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type DataNodeService_UploadChunkStreamServer = grpc.BidiStreamingServer[ChunkDataStream, ChunkDataAck]
+
+func _DataNodeService_DownloadChunkStream_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(DownloadStreamRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(DataNodeServiceServer).DownloadChunkStream(m, &grpc.GenericServerStream[DownloadStreamRequest, ChunkDataStream]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type DataNodeService_DownloadChunkStreamServer = grpc.ServerStreamingServer[ChunkDataStream]
 
 func _DataNodeService_DeleteChunk_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(DeleteChunkRequest)
@@ -216,13 +265,6 @@ func _DataNodeService_DeleteChunk_Handler(srv interface{}, ctx context.Context, 
 	}
 	return interceptor(ctx, in, info, handler)
 }
-
-func _DataNodeService_StreamChunk_Handler(srv interface{}, stream grpc.ServerStream) error {
-	return srv.(DataNodeServiceServer).StreamChunk(&grpc.GenericServerStream[ChunkDataStream, ChunkDataAck]{ServerStream: stream})
-}
-
-// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
-type DataNodeService_StreamChunkServer = grpc.BidiStreamingServer[ChunkDataStream, ChunkDataAck]
 
 func _DataNodeService_HealthCheck_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(HealthCheckRequest)
@@ -254,8 +296,8 @@ var DataNodeService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _DataNodeService_PrepareChunkUpload_Handler,
 		},
 		{
-			MethodName: "RetrieveChunk",
-			Handler:    _DataNodeService_RetrieveChunk_Handler,
+			MethodName: "PrepareChunkDownload",
+			Handler:    _DataNodeService_PrepareChunkDownload_Handler,
 		},
 		{
 			MethodName: "DeleteChunk",
@@ -268,10 +310,15 @@ var DataNodeService_ServiceDesc = grpc.ServiceDesc{
 	},
 	Streams: []grpc.StreamDesc{
 		{
-			StreamName:    "StreamChunk",
-			Handler:       _DataNodeService_StreamChunk_Handler,
+			StreamName:    "UploadChunkStream",
+			Handler:       _DataNodeService_UploadChunkStream_Handler,
 			ServerStreams: true,
 			ClientStreams: true,
+		},
+		{
+			StreamName:    "DownloadChunkStream",
+			Handler:       _DataNodeService_DownloadChunkStream_Handler,
+			ServerStreams: true,
 		},
 	},
 	Metadata: "datanode.proto",

--- a/dfs/pkg/proto/datanode_grpc.pb.go
+++ b/dfs/pkg/proto/datanode_grpc.pb.go
@@ -34,7 +34,7 @@ type DataNodeServiceClient interface {
 	// Hand-shake definitions from peer (upload and download, client or other DataNode)
 	// Both operations follow a 2 step protocol: prepare -> stream data
 	PrepareChunkUpload(ctx context.Context, in *UploadChunkRequest, opts ...grpc.CallOption) (*NodeReady, error)
-	PrepareChunkDownload(ctx context.Context, in *DownloadChunkRequest, opts ...grpc.CallOption) (*NodeReady, error)
+	PrepareChunkDownload(ctx context.Context, in *DownloadChunkRequest, opts ...grpc.CallOption) (*DownloadReady, error)
 	// Bidirectional stream for uploading chunk data to a node.
 	// The client streams data, the server streams back acknowledgements.
 	UploadChunkStream(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[ChunkDataStream, ChunkDataAck], error)
@@ -65,9 +65,9 @@ func (c *dataNodeServiceClient) PrepareChunkUpload(ctx context.Context, in *Uplo
 	return out, nil
 }
 
-func (c *dataNodeServiceClient) PrepareChunkDownload(ctx context.Context, in *DownloadChunkRequest, opts ...grpc.CallOption) (*NodeReady, error) {
+func (c *dataNodeServiceClient) PrepareChunkDownload(ctx context.Context, in *DownloadChunkRequest, opts ...grpc.CallOption) (*DownloadReady, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(NodeReady)
+	out := new(DownloadReady)
 	err := c.cc.Invoke(ctx, DataNodeService_PrepareChunkDownload_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
@@ -134,7 +134,7 @@ type DataNodeServiceServer interface {
 	// Hand-shake definitions from peer (upload and download, client or other DataNode)
 	// Both operations follow a 2 step protocol: prepare -> stream data
 	PrepareChunkUpload(context.Context, *UploadChunkRequest) (*NodeReady, error)
-	PrepareChunkDownload(context.Context, *DownloadChunkRequest) (*NodeReady, error)
+	PrepareChunkDownload(context.Context, *DownloadChunkRequest) (*DownloadReady, error)
 	// Bidirectional stream for uploading chunk data to a node.
 	// The client streams data, the server streams back acknowledgements.
 	UploadChunkStream(grpc.BidiStreamingServer[ChunkDataStream, ChunkDataAck]) error
@@ -158,7 +158,7 @@ type UnimplementedDataNodeServiceServer struct{}
 func (UnimplementedDataNodeServiceServer) PrepareChunkUpload(context.Context, *UploadChunkRequest) (*NodeReady, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PrepareChunkUpload not implemented")
 }
-func (UnimplementedDataNodeServiceServer) PrepareChunkDownload(context.Context, *DownloadChunkRequest) (*NodeReady, error) {
+func (UnimplementedDataNodeServiceServer) PrepareChunkDownload(context.Context, *DownloadChunkRequest) (*DownloadReady, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PrepareChunkDownload not implemented")
 }
 func (UnimplementedDataNodeServiceServer) UploadChunkStream(grpc.BidiStreamingServer[ChunkDataStream, ChunkDataAck]) error {

--- a/dfs/tests/integration/upload_test.go
+++ b/dfs/tests/integration/upload_test.go
@@ -72,7 +72,7 @@ func TestClientUpload(t *testing.T) {
 			}
 
 			uploadAt := filepath.Join(baseUploadAt, tt.filepath, strconv.Itoa(rand.Intn(1000000)))
-			if _, err := client.UploadFile(context.Background(), file, uploadAt, defaultChunkSize); err != nil {
+			if err := client.UploadFile(context.Background(), file, uploadAt, defaultChunkSize); err != nil {
 				t.Errorf("failed to upload file: %v", err)
 			}
 			file.Close()
@@ -120,7 +120,7 @@ func TestClientUpload(t *testing.T) {
 			}
 
 			uploadAt := filepath.Join(baseUploadAt, tt.filepath, strconv.Itoa(rand.Intn(1000000)))
-			if _, err := client.UploadFile(context.Background(), file, uploadAt, tt.chunkSize); err != nil {
+			if err := client.UploadFile(context.Background(), file, uploadAt, tt.chunkSize); err != nil {
 				t.Errorf("failed to upload file: %v", err)
 			}
 

--- a/dfs/tests/integration/upload_test.go
+++ b/dfs/tests/integration/upload_test.go
@@ -65,7 +65,7 @@ func TestClientUpload(t *testing.T) {
 
 	for _, tt := range fileSizeTestCases {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			// t.Parallel()
 
 			path := filepath.Join(testFilesDir, tt.filepath)
 			file, err := os.Open(path)
@@ -84,6 +84,8 @@ func TestClientUpload(t *testing.T) {
 			streamer := common.NewStreamer(common.StreamerConfig{
 				ChunkStreamSize: defaultChunkSize,
 			})
+			streamer.Config.WaitReplicas = true // Wait for the final stream with the replicas information
+
 			for _, info := range chunkInfos {
 				for _, replica := range info.Replicas {
 					dnClient, _ := datanode.NewDataNodeClient(replica)
@@ -99,7 +101,7 @@ func TestClientUpload(t *testing.T) {
 
 					stream, err := dnClient.DownloadChunkStream(context.Background(), common.DownloadStreamRequest{
 						SessionID:       resp.SessionID,
-						ChunkStreamSize: int32(defaultChunkSize),
+						ChunkStreamSize: int32(common.DefaultStreamerConfig().ChunkStreamSize), // Follows the default chunk stream size -- 256KB
 					})
 					if err != nil {
 						t.Errorf("failed to create download stream: %v", err)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,29 +1,110 @@
-# Distributed file system architecture
+# Architecture
 
-This document lays out the architecture for the distributed file system.
+This document complements [`docs/design.md`](design.md) by focussing on the
+responsibilities of every component and how they interact at runtime.
 
-## Coordinator Node
+---
 
-#### Server endpoints
-- Upload
-    - Validate if requested Path is available for upload
-    - Idenfity candidate data nodes for each data chunk
-    - Reply with where the client should upload each chunk (primary + replicas)
+## Components
 
-- Download
-    - Validate required Path has some file
+| Component | Responsibility | Key packages |
+|-----------|----------------|--------------|
+| **Coordinator** | • Maintain file-system metadata (path → chunk list).  \
+  • Track DataNode membership & health via heart-beats.  \
+  • Plan uploads / downloads. | `internal/coordinator` |
+| **DataNode** | • Store chunk bytes on local disk.  \
+  • Serve uploads & downloads via gRPC streams.  \
+  • Replicate chunks to peer nodes. | `internal/datanode` + `internal/storage` |
+| **Client SDK / CLI** | • Split files into chunks & compute checksums.  \
+  • Drive upload/download flows.  \
+  • Expose simple CLI for manual testing. | `internal/client` |
+| **Streamer** | Zero-copy framing, retries and back-pressure for any
+  `ChunkDataStream` (client → node or node → node). | `internal/common/streamer.go` |
 
-#### Client operations
+---
 
+## Coordinator endpoints
 
+| RPC | Description |
+|-----|-------------|
+| `UploadFile(UploadRequest)` | Returns chunk plan (primary + replicas). |
+| `ConfirmUpload(ConfirmUploadRequest)` | Commits metadata after client confirms all chunks uploaded. |
+| `DownloadFile(DownloadRequest)` | Returns chunk map + file info. |
+| `RegisterDataNode(RegisterDataNodeRequest)` | Called once at node start-up. |
+| `DataNodeHeartbeat(HeartbeatRequest)` | Periodic health + disk usage update; returns incremental node updates. |
 
-#### Metadada
+`internal/common/types.go` contains Go equivalents of most protobuf messages.
 
+---
 
-#### Coordinator distributed architecture
+## DataNode gRPC surface
 
-- Single leader architecture
+| RPC | Direction | Purpose |
+|-----|-----------|---------|
+| `PrepareChunkUpload` | unary | Ask a node if it can accept the chunk. |
+| `UploadChunkStream` | bidi stream | Push chunk bytes (client → primary, primary → replica). |
+| `PrepareChunkDownload` | unary | Validate chunk exists and create session. |
+| `DownloadChunkStream` | server stream | Stream chunk bytes to client / peer. |
+| `DeleteChunk` | unary | Remove a chunk. |
+| `HealthCheck` | unary | Optional liveness probe. |
 
-## Data Node
+---
 
-## Client
+## Streaming protocol (ChunkDataStream)
+Every message contains:
+
+* `session_id` – UUID from the *Prepare* phase.
+* `chunk_id` – unique per chunk.
+* `offset` – byte offset of `data` relative to start of chunk.
+* `is_final` – last frame flag.
+* `partial_checksum` – SHA-256 of this frame (allows early detection).
+
+The receiver responds with `ChunkDataAck{bytes_received, ready_for_next}` which
+enables back-pressure: when the DataNode's buffer exceeds a threshold it can
+set `ready_for_next=false` so the sender pauses.
+
+---
+
+## Failure handling
+
+| Failure | Detection | Recovery |
+|---------|-----------|----------|
+| **Client disconnects** while primary is still replicating | Replica's `stream.Recv()` returns `Canceled`. | Primary aborts replication; client may retry the whole chunk. |
+| **Replica timeout** | Primary waits `REPLICATE_TIMEOUT` per replica. | If replicas < required, primary returns error → client retry. |
+| **Checksum mismatch** | Verified after stream closes. | Chunk is discarded; upload fails; client retry. |
+
+---
+
+## Build-time constants vs runtime config
+Currently two values are compile-time constants:
+
+* `N_REPLICAS` (default 3)
+* `N_NODES` (used to pre-select candidates)
+
+They live at the top of `internal/datanode/server.go`.  Making them runtime
+configurable is tracked in [issue #56](https://github.com/mochivi/distributed-file-system/issues/56).
+
+---
+
+## Package dependency diagram
+
+```mermaid
+flowchart TD
+    client --> common
+    datanode --> common
+    datanode --> storage
+    coordinator --> common
+    storage --> encoding
+    common --> pkgproto
+    datanode --> pkgproto
+    coordinator --> pkgproto
+    client --> pkgproto
+```
+
+---
+
+## Glossary
+* **Chunk** – immutable byte sequence (~16–64 MiB) identified by ID `hash_index`.
+* **Primary** – DataNode that first receives a chunk from the client.
+* **Replica** – DataNode that receives the chunk from the primary.
+* **Session** – Temporary state (checksum, buffer) keyed by `session_id` during a stream.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,43 @@
+# Configuration reference
+
+DFS services are configured primarily via **environment variables**.  All
+variables are optional; sensible defaults allow the demo cluster to start with
+no additional configuration.
+
+| Variable | Component | Default | Description |
+|----------|-----------|---------|-------------|
+| `COORDINATOR_HOST` | all | `coordinator` | Hostname (or IP) where coordinator is reachable. |
+| `COORDINATOR_PORT` | all | `8080` | gRPC port exposed by coordinator. |
+| `DATANODE_HOST`    | datanode | container hostname | Address advertised to peers – must be reachable by all nodes. |
+| `DATANODE_PORT`    | datanode | `8081` | gRPC port that the DataNode listens on. |
+| `DISK_STORAGE_BASE_DIR` | datanode | `/app` | Root directory where chunks are stored on disk. |
+| `REPLICATE_TIMEOUT`| datanode | `2m` | Timeout for each replica upload. |
+| `SESSION_TIMEOUT`  | datanode | `1m` | Streaming-session idle timeout. |
+| `CHUNK_STREAM_SIZE`| streamer | `262144` (256 KiB) | Size of each frame sent over the `ChunkDataStream`. |
+| `MAX_CHUNK_RETRIES`| streamer | `3` | How many times the streamer retries sending the same frame. |
+| `BACKPRESSURE_TIME`| streamer | `0s` | Optional delay when replica responds `readyForNext=false`. |
+| `WAIT_REPLICAS`    | client   | `true` | Whether the client waits for the replica-ack frame. |
+
+Environment variables are read in `internal/.../config.go` via helper
+`pkg/utils/env.go`.
+
+---
+
+## Example `.env` file
+```dotenv
+# coordinator
+COORDINATOR_PORT=9090
+
+# datanode
+DATANODE_HOST=datanode1
+DATANODE_PORT=9091
+DISK_STORAGE_BASE_DIR=/data
+REPLICATE_TIMEOUT=5m
+
+# streamer
+CHUNK_STREAM_SIZE=1048576   # 1 MiB
+```
+
+Load it with Docker Compose:
+```bash
+docker compose --env-file .env up -d 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,141 @@
+# Deployment guide
+
+This document shows a few ways to run DFS beyond the local docker-compose
+cluster used during development.
+
+---
+
+## 1. Docker Compose (development / CI)
+The file [`docker-compose.test.yml`](../docker-compose.test.yml) declares:
+* 1 × Coordinator (`8080`)
+* 6 × DataNodes (`8081`) each with an ephemeral volume mounted at `/app/data`
+* 1 × integration-runner service that runs `go test`
+
+Start:
+```bash
+docker compose -f docker-compose.test.yml up -d
+```
+
+Tear down:
+```bash
+docker compose -f docker-compose.test.yml down --volumes
+```
+
+Override environment variables (see `docs/configuration.md`) using an `.env`
+file or `-e` flags.
+
+---
+
+## 2. Stand-alone binaries
+Build the coordinator and datanode binaries:
+```bash
+make build
+```
+
+Run coordinator:
+```bash
+./bin/coordinator --port 8080
+```
+
+Run a datanode that registers with the coordinator:
+```bash
+export COORDINATOR_HOST=localhost
+export DATANODE_HOST=127.0.0.1
+./bin/datanode --port 8081 --data-dir /var/dfs
+```
+
+> 🚨**Note:** You need at least **3** DataNodes to satisfy the default
+> replication factor.
+
+---
+
+## 3. Kubernetes
+An example Helm chart is planned (see issue #61).  Until then you can run the
+containers directly:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coordinator
+spec:
+  replicas: 1
+  selector: {matchLabels: {app: coordinator}}
+  template:
+    metadata: {labels: {app: coordinator}}
+    spec:
+      containers:
+        - name: coordinator
+          image: mochivi/dfs-coordinator:latest
+          ports: [{containerPort: 8080}]
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: datanode
+spec:
+  serviceName: datanode
+  replicas: 3
+  selector: {matchLabels: {app: datanode}}
+  template:
+    metadata: {labels: {app: datanode}}
+    spec:
+      containers:
+        - name: datanode
+          image: mochivi/dfs-datanode:latest
+          env:
+            - name: COORDINATOR_HOST
+              value: coordinator
+          ports: [{containerPort: 8081}]
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+  volumeClaimTemplates:
+    - metadata: {name: data}
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources: {requests: {storage: 20Gi}}
+```
+Apply:
+```bash
+kubectl apply -f dfs-cluster.yaml
+```
+
+---
+
+## 4. Systemd service (bare-metal)
+Install binaries under `/usr/local/bin/dfs-*` and create:
+
+`/etc/dfs/datanode.env`
+```ini
+COORDINATOR_HOST=coordinator.service.local
+DATANODE_HOST=$(hostname -f)
+REPLICATE_TIMEOUT=5m
+```
+
+`/etc/systemd/system/dfs-datanode.service`
+```ini
+[Unit]
+Description=DFS DataNode
+After=network.target dfs-coordinator.service
+
+[Service]
+EnvironmentFile=/etc/dfs/datanode.env
+ExecStart=/usr/local/bin/dfs-datanode --port 8081 --data-dir /var/lib/dfs
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable & start:
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now dfs-datanode
+```
+
+---
+
+## Monitoring & metrics
+• All services export JSON logs and can be collected by Fluent-bit.  
+• Prometheus metrics endpoint (`/metrics`) is planned.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,0 +1,59 @@
+# Wire protocol
+
+DFS uses **Protocol Buffers** over **gRPC (HTTP/2)** for all service‐to‐service
+communication.  This document summarises the key message types and RPCs.  Full
+IDL lives in [`pkg/proto/*.proto`](../pkg/proto/).
+
+---
+
+## Messages
+| Message | Purpose |
+|---------|---------|
+| `ChunkMeta` | Identifier of a chunk (`chunk_id`, `checksum`, `size`). |
+| `ChunkData` | Frame inside `ChunkDataStream` (data + offset + flags). |
+| `ChunkDataAck` | Acknowledgement for a `ChunkData` frame. |
+| `ChunkReplicas` | Final ack that carries the list of replicas that succeeded. |
+| `UploadPlan` | Returned by coordinator – mapping of chunk → nodes. |
+| `NodeInfo` | Heart-beat payload (free, total, health). |
+
+See `common.proto`, `coordinator.proto`, `datanode.proto` for exact fields.
+
+---
+
+## RPC matrix
+
+| Service | RPC | Type | Notes |
+|---------|-----|------|-------|
+| Coordinator | `UploadFile` | unary | Plan upload, returns `UploadPlan`. |
+|   | `ConfirmUpload` | unary | Atomically commit metadata. |
+|   | `DownloadFile` | unary | Returns chunk map. |
+|   | `RegisterDataNode` | unary | Node joins cluster. |
+|   | `DataNodeHeartbeat` | bidi stream | Node sends `Heartbeat`; server streams delta updates. |
+| DataNode | `PrepareChunkUpload` | unary | Capacity & checksum pre-flight; returns session ID. |
+|   | `UploadChunkStream` | bidi stream | Client sends `ChunkData`; server acks and finally `ChunkReplicas`. |
+|   | `PrepareChunkDownload` | unary | Validate chunk exists; returns session ID. |
+|   | `DownloadChunkStream` | server stream | Stream `ChunkData` frames. |
+|   | `ReplicateChunk` | bidi stream | Same as upload but node→node. |
+
+---
+
+## Session lifecycle
+1. Client calls `PrepareChunkUpload` on primary node → gets `session_id`.
+2. Opens `UploadChunkStream` with that ID.
+3. Streams data frames; each frame is 256 KiB by default.
+4. Primary replies with `ChunkDataAck` frames; when `is_final=true` verifies
+   checksum and stores to disk.
+5. Primary fans out to replicas via `ReplicateChunk` (same session ID to ease
+   tracing).
+6. When the required number of replicas acknowledge, primary sends
+   `ChunkReplicas{replicas[]}` back to the client and closes the stream.
+
+---
+
+## Forward / backward compatibility
+* **Field additions** are safe – proto3 reserves unknown fields.
+* **Required to optional** – avoid; prefer new optional field.
+* **Tag number changes** – not allowed; they are the wire key.
+
+Protobuf compiler version is pinned in `go.mod` (`google.golang.org/protobuf`)
+so regeneration is reproducible.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,16 @@
+# Troubleshooting
+
+Common issues and their resolutions while running DFS locally.
+
+| Error / Symptom | Root cause | Resolution |
+|-----------------|------------|------------|
+| `rpc error: code = Canceled desc = context canceled` in DataNode log | The peer (client or upstream node) closed the gRPC stream while this node was still reading. Most often happens when the test process exits before replicas finish. | Increase `REPLICATE_TIMEOUT`, wait for goroutines (`sync.WaitGroup`) before exiting, or set `WAIT_REPLICAS=false` during tests. |
+| `failed to receive replicas response: EOF` on client | The primary DataNode closed the stream because replication did not complete within `REPLICATE_TIMEOUT`. | Tune `REPLICATE_TIMEOUT` or reduce chunk size / increase network throughput. |
+| `insufficient replicas` error inside DataNode | Not enough healthy nodes available to satisfy `N_REPLICAS-1` replicas. | Start more DataNodes or lower replication factor (compile-time constant for now). |
+| `address already in use` when starting compose | Ports 8080 / 8081 are occupied. | Stop previous cluster (`make integration-down`) or change ports in compose file. |
+| `checksum mismatch` during upload | File changed between checksum computation and streaming or data corrupted in transit. | Ensure file is immutable during upload; verify network; check for concurrent writes. |
+| `dial tcp ... i/o timeout` from client | Coordinator / DataNode not reachable (container died, wrong host). | `docker compose ps` to inspect, restart containers, verify `COORDINATOR_HOST`. |
+
+If the issue is not listed open a GitHub issue with logs from `./logs/`.  Most
+services use [slog](https://pkg.go.dev/log/slog) – increase verbosity by setting
+`LOG_LEVEL=debug` on the container. 


### PR DESCRIPTION
### Overview

This branch closes the end-to-end loop by adding the download path, hardening replication, extending the test-suite and bringing the documentation up-to-date.

### Key changes

- Download implementation
  - Coordinator RPC DownloadFile

  - DataNode RPCs: PrepareChunkDownload and DownloadChunkStream
  
  - Client downloader (internal/client/downloader.go) and CLI command

- Streamer reuse for downloads with back-pressure and retries

- ReplicationManager refactor: clearer error aggregation and timeout handling

- Heart-beat loop: exponential back-off, improved logging

- Storage: zero-copy streaming helpers in ChunkStore

### Tests

- Integration cases for upload and download across multiple file sizes

- Failure scenarios: checksum mismatch, replica timeout

- Serial execution to avoid premature stream closure

- CI workflow: lint, unit tests, integration tests, log upload

### Documentation overhaul

- Re-written README.md

- New pages: architecture, configuration, deployment, protocol, troubleshooting